### PR TITLE
Changes for Plugin to work in UE5

### DIFF
--- a/Source/GitSourceControl/GitSourceControl.Build.cs
+++ b/Source/GitSourceControl/GitSourceControl.Build.cs
@@ -26,6 +26,7 @@ public class GitSourceControl : ModuleRules
 				"EditorStyle",
 				"UnrealEd",
 				"SourceControl",
+				"SourceControlWindows",
 				"Projects"
 			}
 		);

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.h
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.h
@@ -7,6 +7,7 @@
 
 #include "CoreMinimal.h"
 #include "ISourceControlProvider.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 class FToolBarBuilder;
 class FMenuBuilder;
@@ -19,6 +20,7 @@ public:
 	void Unregister();
 	
 	/** This functions will be bound to appropriate Command. */
+	void CommitClicked();
 	void PushClicked();
 	void SyncClicked();
 	void RevertClicked();
@@ -46,7 +48,11 @@ private:
 	static void DisplayFailureNotification(const FName& InOperationName);
 
 private:
+#if ENGINE_MAJOR_VERSION < 5
 	FDelegateHandle ViewMenuExtenderHandle;
+#else
+	TSharedPtr<FExtender> ViewMenuExtender;
+#endif
 
 	/** Was there a need to stash away modifications before Sync? */
 	bool bStashMadeBeforeSync;


### PR DESCRIPTION
Made changes to allow for usage in UE5 with a Menu, due to missing Source Control level editor extension at this point in time.

This is not a standalone fix, it obviously needs the changes from pb-changes-ue5, but due to ifdef guards they can be put into the main branch. But can also make another PR if you'd rather just have it on the pb-changes-ue5.