### PR TITLE
Pb changes ue5

### DIFF
--- a/Source/GitSourceControl/GitSourceControl.Build.cs
+++ b/Source/GitSourceControl/GitSourceControl.Build.cs
@@ -24,7 +24,6 @@ public class GitSourceControl : ModuleRules
 				"InputCore",
 				"DesktopWidgets",
 				"EditorStyle",
-				"EditorFramework",
 				"UnrealEd",
 				"SourceControl",
 				"SourceControlWindows",

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -9,8 +9,11 @@
 #include "Modules/ModuleManager.h"
 #include "Features/IModularFeatures.h"
 
-#include "ContentBrowser/Public/ContentBrowserModule.h"
 #include "GitSourceControlOperations.h"
+
+#if ENGINE_MAJOR_VERSION >= 5
+#include "ContentBrowser/Public/ContentBrowserModule.h"
+#endif
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"
 

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -275,10 +275,12 @@ ECommandResult::Type FGitSourceControlProvider::GetState( const TArray<FString>&
 	return ECommandResult::Succeeded;
 }
 
+#if ENGINE_MAJOR_VERSION >= 5
 ECommandResult::Type FGitSourceControlProvider::GetState(const TArray<FSourceControlChangelistRef>& InChangelists, TArray<FSourceControlChangelistStateRef>& OutState, EStateCacheUsage::Type InStateCacheUsage)
 {
     return ECommandResult::Failed;
 }
+#endif
 
 TArray<FSourceControlStateRef> FGitSourceControlProvider::GetCachedStateByPredicate(TFunctionRef<bool(const FSourceControlStateRef&)> Predicate) const
 {
@@ -330,7 +332,11 @@ void FGitSourceControlProvider::UnregisterSourceControlStateChanged_Handle( FDel
 	OnSourceControlStateChanged.Remove( Handle );
 }
 
+#if ENGINE_MAJOR_VERSION < 5
+ECommandResult::Type FGitSourceControlProvider::Execute( const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, const TArray<FString>& InFiles, EConcurrency::Type InConcurrency, const FSourceControlOperationComplete& InOperationCompleteDelegate )
+#else
 ECommandResult::Type FGitSourceControlProvider::Execute( const FSourceControlOperationRef& InOperation, FSourceControlChangelistPtr InChangelist, const TArray<FString>& InFiles, EConcurrency::Type InConcurrency, const FSourceControlOperationComplete& InOperationCompleteDelegate )
+#endif
 {
 	if(!IsEnabled() && !(InOperation->GetName() == "Connect")) // Only Connect operation allowed while not Enabled (Repository found)
 	{
@@ -382,7 +388,11 @@ ECommandResult::Type FGitSourceControlProvider::Execute( const FSourceControlOpe
 	}
 }
 
+#if ENGINE_MAJOR_VERSION < 5
+bool FGitSourceControlProvider::CanCancelOperation( const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation ) const
+#else
 bool FGitSourceControlProvider::CanCancelOperation( const FSourceControlOperationRef& InOperation ) const
+#endif
 {
 	// TODO: maybe support cancellation again?
 #if 0
@@ -401,7 +411,11 @@ bool FGitSourceControlProvider::CanCancelOperation( const FSourceControlOperatio
 	return false;
 }
 
+#if ENGINE_MAJOR_VERSION < 5
+void FGitSourceControlProvider::CancelOperation( const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation )
+#else
 void FGitSourceControlProvider::CancelOperation( const FSourceControlOperationRef& InOperation )
+#endif
 {
 	for (int32 CommandIndex = 0; CommandIndex < CommandQueue.Num(); ++CommandIndex)
 	{
@@ -548,10 +562,12 @@ TArray< TSharedRef<ISourceControlLabel> > FGitSourceControlProvider::GetLabels( 
 	return Tags;
 }
 
+#if ENGINE_MAJOR_VERSION >= 5
 TArray<FSourceControlChangelistRef> FGitSourceControlProvider::GetChangelists( EStateCacheUsage::Type InStateCacheUsage )
 {
     return TArray<FSourceControlChangelistRef>();
 }
+#endif
 
 #if SOURCE_CONTROL_WITH_SLATE
 TSharedRef<class SWidget> FGitSourceControlProvider::MakeSettingsWidget() const

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -583,7 +583,9 @@ ECommandResult::Type FGitSourceControlProvider::ExecuteSynchronousCommand(FGitSo
 
 	// Display the progress dialog if a string was provided
 	{
-		FScopedSourceControlProgress Progress(TaskText, FSimpleDelegate::CreateStatic(&Local::CancelCommand, &InCommand));
+		// TODO: support cancellation?
+		//FScopedSourceControlProgress Progress(TaskText, FSimpleDelegate::CreateStatic(&Local::CancelCommand, &InCommand));
+		FScopedSourceControlProgress Progress(TaskText);
 		
 		// Issue the command asynchronously...
 		IssueCommand( InCommand );

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.h
@@ -76,19 +76,31 @@ public:
 	virtual void RegisterStateBranches(const TArray<FString>& BranchNames, const FString& ContentRootIn) override;
 	virtual int32 GetStateBranchIndex(const FString& BranchName) const override;
 	virtual ECommandResult::Type GetState( const TArray<FString>& InFiles, TArray<FSourceControlStateRef>& OutState, EStateCacheUsage::Type InStateCacheUsage ) override;
-	virtual ECommandResult::Type GetState(const TArray<FSourceControlChangelistRef>& InChangelists, TArray<FSourceControlChangelistStateRef>& OutState, EStateCacheUsage::Type InStateCacheUsage) override;
+#if ENGINE_MAJOR_VERSION >= 5
+        virtual ECommandResult::Type GetState(const TArray<FSourceControlChangelistRef>& InChangelists, TArray<FSourceControlChangelistStateRef>& OutState, EStateCacheUsage::Type InStateCacheUsage) override;
+#endif
 	virtual TArray<FSourceControlStateRef> GetCachedStateByPredicate(TFunctionRef<bool(const FSourceControlStateRef&)> Predicate) const override;
 	virtual FDelegateHandle RegisterSourceControlStateChanged_Handle(const FSourceControlStateChanged::FDelegate& SourceControlStateChanged) override;
 	virtual void UnregisterSourceControlStateChanged_Handle(FDelegateHandle Handle) override;
+#if ENGINE_MAJOR_VERSION < 5
+	virtual ECommandResult::Type Execute( const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, const TArray<FString>& InFiles, EConcurrency::Type InConcurrency = EConcurrency::Synchronous, const FSourceControlOperationComplete& InOperationCompleteDelegate = FSourceControlOperationComplete()) override;
+	virtual bool CanCancelOperation( const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation ) const override;
+	virtual void CancelOperation( const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation ) override;
+#else
 	virtual ECommandResult::Type Execute(const FSourceControlOperationRef& InOperation, FSourceControlChangelistPtr InChangelist, const TArray<FString>& InFiles, EConcurrency::Type InConcurrency = EConcurrency::Synchronous, const FSourceControlOperationComplete& InOperationCompleteDelegate = FSourceControlOperationComplete()) override;
 	virtual bool CanCancelOperation( const FSourceControlOperationRef& InOperation ) const override;
 	virtual void CancelOperation( const FSourceControlOperationRef& InOperation ) override;
+#endif
 	virtual bool UsesLocalReadOnlyState() const override;
 	virtual bool UsesChangelists() const override;
 	virtual bool UsesCheckout() const override;
 	virtual void Tick() override;
 	virtual TArray< TSharedRef<class ISourceControlLabel> > GetLabels( const FString& InMatchingSpec ) const override;
+
+#if ENGINE_MAJOR_VERSION >= 5
 	virtual TArray<FSourceControlChangelistRef> GetChangelists( EStateCacheUsage::Type InStateCacheUsage ) override;
+#endif
+
 #if SOURCE_CONTROL_WITH_SLATE
 	virtual TSharedRef<class SWidget> MakeSettingsWidget() const override;
 #endif

--- a/Source/GitSourceControl/Private/GitSourceControlState.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlState.cpp
@@ -4,7 +4,10 @@
 // or copy at http://opensource.org/licenses/MIT)
 
 #include "GitSourceControlState.h"
+
+#if ENGINE_MAJOR_VERSION >= 5
 #include "Styling/AppStyle.h"
+#endif
 
 #define LOCTEXT_NAMESPACE "GitSourceControl.State"
 
@@ -59,33 +62,75 @@ TSharedPtr<class ISourceControlRevision, ESPMode::ThreadSafe> FGitSourceControlS
 	return nullptr;
 }
 
+// @todo add Slate icons for git specific states (NotAtHead vs Conflicted...)
+
+#if ENGINE_MAJOR_VERSION < 5
+#define GET_ICON_RETURN( NAME ) FName( NAME )
+FName FGitSourceControlState::GetIconName() const
+{
+#else
+#define GET_ICON_RETURN( NAME ) FSlateIcon(FAppStyle::GetAppStyleSetName(), NAME )
 FSlateIcon FGitSourceControlState::GetIcon() const
 {
+#endif
 	switch (GetGitState())
 	{
 	case EGitState::NotAtHead:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.NotAtHeadRevision");
+		return GET_ICON_RETURN("Perforce.NotAtHeadRevision");
 	case EGitState::LockedOther:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.CheckedOutByOtherUser");
+		return GET_ICON_RETURN("Perforce.CheckedOutByOtherUser");
 	case EGitState::NotLatest:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.ModifiedOtherBranch");
+		return GET_ICON_RETURN("Perforce.ModifiedOtherBranch");
 	case EGitState::Unmerged:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.Branched");
+		return GET_ICON_RETURN("Perforce.Branched");
 	case EGitState::Added:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.OpenForAdd");
+		return GET_ICON_RETURN("Perforce.OpenForAdd");
 	case EGitState::Untracked:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.NotInDepot");
+		return GET_ICON_RETURN("Perforce.NotInDepot");
 	case EGitState::Deleted:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.MarkedForDelete");
+		return GET_ICON_RETURN("Perforce.MarkedForDelete");
 	case EGitState::Modified:
 	case EGitState::CheckedOut:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.CheckedOut");
+		return GET_ICON_RETURN("Perforce.CheckedOut");
 	case EGitState::Ignored:
-		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.NotInDepot");
+		return GET_ICON_RETURN("Perforce.NotInDepot");
 	default:
-		return FSlateIcon();
+#if ENGINE_MAJOR_VERSION < 5
+	  return NAME_None;
+#else
+	  return {};
+#endif
 	}
 }
+
+#if ENGINE_MAJOR_VERSION < 5
+FName FGitSourceControlState::GetSmallIconName() const
+{
+	switch (GetGitState()) {
+	case EGitState::NotAtHead:
+	  return FName("Perforce.NotAtHeadRevision_Small");
+	case EGitState::LockedOther:
+	  return FName("Perforce.CheckedOutByOtherUser_Small");
+	case EGitState::NotLatest:
+	  return FName("Perforce.ModifiedOtherBranch_Small");
+	case EGitState::Unmerged:
+	  return FName("Perforce.Branched_Small");
+	case EGitState::Added:
+	  return FName("Perforce.OpenForAdd_Small");
+	case EGitState::Untracked:
+	  return FName("Perforce.NotInDepot_Small");
+	case EGitState::Deleted:
+	  return FName("Perforce.MarkedForDelete_Small");
+	case EGitState::Modified:
+        case EGitState::CheckedOut:
+                return FName("Perforce.CheckedOut_Small");
+	case EGitState::Ignored:
+	  return FName("Perforce.NotInDepot_Small");
+	default:
+	  return NAME_None;
+	}
+}
+#endif
 
 FText FGitSourceControlState::GetDisplayName() const
 {

--- a/Source/GitSourceControl/Private/GitSourceControlState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlState.h
@@ -9,6 +9,7 @@
 #include "ISourceControlState.h"
 #include "ISourceControlRevision.h"
 #include "GitSourceControlRevision.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 /** A consolidation of state priorities. */
 namespace EGitState
@@ -116,23 +117,14 @@ namespace ERemoteState
 /** Combined state, for updating cache in a map. */
 struct FGitState
 {
-	EFileState::Type FileState;
-	ETreeState::Type TreeState;
-	ELockState::Type LockState;
+	EFileState::Type FileState = EFileState::Unknown;
+	ETreeState::Type TreeState = ETreeState::NotInRepo;
+	ELockState::Type LockState = ELockState::Unknown;
 	/** Name of user who has locked the file */
 	FString LockUser;
-	ERemoteState::Type RemoteState;
+	ERemoteState::Type RemoteState = ERemoteState::UpToDate;
 	/** The branch with the latest commit for this file */
 	FString HeadBranch;
-
-	FGitState()
-		: FileState(EFileState::Unknown)
-		, TreeState(ETreeState::NotInRepo)
-		, LockState(ELockState::Unknown)
-		, LockUser(TEXT(""))
-		, RemoteState(ERemoteState::UpToDate)
-	{
-	}
 };
 
 class FGitSourceControlState : public ISourceControlState, public TSharedFromThis<FGitSourceControlState, ESPMode::ThreadSafe>
@@ -140,9 +132,8 @@ class FGitSourceControlState : public ISourceControlState, public TSharedFromThi
 public:
 	FGitSourceControlState( const FString& InLocalFilename)
 		: LocalFilename(InLocalFilename)
-		, TimeStamp(0)
-		, HeadCommit(TEXT("Unknown"))
 		, HeadAction(TEXT("Changed"))
+		, HeadCommit(TEXT("Unknown"))
 	{
 	}
 
@@ -152,7 +143,12 @@ public:
 	virtual TSharedPtr<class ISourceControlRevision, ESPMode::ThreadSafe> FindHistoryRevision(int32 RevisionNumber) const override;
 	virtual TSharedPtr<class ISourceControlRevision, ESPMode::ThreadSafe> FindHistoryRevision(const FString& InRevision) const override;
 	virtual TSharedPtr<class ISourceControlRevision, ESPMode::ThreadSafe> GetBaseRevForMerge() const override;
+#if ENGINE_MAJOR_VERSION >= 5
 	virtual FSlateIcon GetIcon() const override;
+#else
+	virtual FName GetIconName() const override;
+	virtual FName GetSmallIconName() const override;
+#endif
 	virtual FText GetDisplayName() const override;
 	virtual FText GetDisplayTooltip() const override;
 	virtual const FString& GetFilename() const override;

--- a/Source/GitSourceControl/Private/GitSourceControlState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlState.h
@@ -122,6 +122,8 @@ struct FGitState
 	/** Name of user who has locked the file */
 	FString LockUser;
 	ERemoteState::Type RemoteState;
+	/** The branch with the latest commit for this file */
+	FString HeadBranch;
 
 	FGitState()
 		: FileState(EFileState::Unknown)
@@ -139,7 +141,8 @@ public:
 	FGitSourceControlState( const FString& InLocalFilename)
 		: LocalFilename(InLocalFilename)
 		, TimeStamp(0)
-		, HeadAction(TEXT("changed"))
+		, HeadCommit(TEXT("Unknown"))
+		, HeadAction(TEXT("Changed"))
 	{
 	}
 
@@ -195,9 +198,6 @@ public:
 
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;
-
-	/** The branch with the latest commit for this file */
-	FString HeadBranch;
 
 	/** The action within the head branch TODO */
 	FString HeadAction;

--- a/Source/GitSourceControl/Private/SGitSourceControlSettings.h
+++ b/Source/GitSourceControl/Private/SGitSourceControlSettings.h
@@ -31,6 +31,7 @@ public:
 	~SGitSourceControlSettings();
 
 private:
+	void ConstructBasedOnEngineVersion( );
 
 	/** Delegates to get Git binary path from/to settings */
 	FString GetBinaryPathString() const;


### PR DESCRIPTION
Includes last two commits from pb-changes
This PR's purpose is to make the maintenance of two separate branches obsolete.

Once this is merged in, pb-changes-ue5 will work for both UE4 & UE5.