### PR TITLE
Fixed revert failure due to OS file locks by Git

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -531,8 +531,8 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 			// revert any changes in working copy (this would fails if the asset was in "Added" state, since after "reset" it is now "untracked")
 			// may need to try a few times due to file locks from prior operations
 			bool CheckoutSuccess = false;
-			int32 Attempts = 0;
-			while( --Attempts >= 0 )
+			int32 Attempts = 10;
+			while( Attempts-- > 0 )
 			{
 				CheckoutSuccess = GitSourceControlUtils::RunCommand(TEXT("checkout"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), OtherThanAddedExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 				if (CheckoutSuccess)

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -17,6 +17,9 @@
 #include "Logging/MessageLog.h"
 #include "Misc/MessageDialog.h"
 
+#include <chrono>
+#include <thread>
+
 #define LOCTEXT_NAMESPACE "GitSourceControl"
 
 FName FGitConnectWorker::GetName() const
@@ -525,7 +528,20 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 		if (OtherThanAddedExistingFiles.Num() > 0)
 		{
 			// revert any changes in working copy (this would fails if the asset was in "Added" state, since after "reset" it is now "untracked")
-			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("checkout"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), OtherThanAddedExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+			// may need to try a few times due to file locks from prior operations
+			bool CheckoutSuccess = false;
+			for (int32 i = 0; i < 10; ++i)
+			{
+				CheckoutSuccess = GitSourceControlUtils::RunCommand(TEXT("checkout"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), OtherThanAddedExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+				if (CheckoutSuccess)
+				{
+					break;
+				}
+
+				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			}
+			
+			InCommand.bCommandSuccessful &= CheckoutSuccess;
 		}
 	}
 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2105,9 +2105,7 @@ bool PullOrigin(const FString& InPathToGitBinary, const FString& InPathToReposit
 
 	// Get the list of files which will be updated (either ones we changed locally, which will get potentially rebased or merged, or the remote ones that will update)
 	TArray<FString> DifferentFiles;
-	TArray<FString> Parameters {TEXT("--name-only"), RemoteBranch};
-	const bool bResultDiff = RunCommand(TEXT("diff"), InPathToGitBinary, InPathToRepositoryRoot, Parameters, FGitSourceControlModule::GetEmptyStringArray(),
-										DifferentFiles, OutErrorMessages);
+	const bool bResultDiff = RunCommand(TEXT("diff"), InPathToGitBinary, InPathToRepositoryRoot, { TEXT("--name-only"), RemoteBranch }, FGitSourceControlModule::GetEmptyStringArray(), DifferentFiles, OutErrorMessages);
 	if (!bResultDiff)
 	{
 		return false;
@@ -2158,11 +2156,7 @@ bool PullOrigin(const FString& InPathToGitBinary, const FString& InPathToReposit
 
 	// Reset HEAD and index to remote
 	TArray<FString> InfoMessages;
-	Parameters.Reset(2);
-	Parameters.Append({
-		"--rebase", "--autostash"
-	});
-	bool bSuccess = RunCommand(TEXT("pull"), InPathToGitBinary, InPathToRepositoryRoot, Parameters, FGitSourceControlModule::GetEmptyStringArray(),
+	bool bSuccess = RunCommand(TEXT("pull"), InPathToGitBinary, InPathToRepositoryRoot, { "--rebase", "--autostash" }, FGitSourceControlModule::GetEmptyStringArray(),
 										  InfoMessages, OutErrorMessages);
 
 	if (bShouldReload)


### PR DESCRIPTION
Git reset acquires a file lock that's not release in time in half the cases before git checkout runs, making git checkout fail.
I added a loop of tries and a sleep to make sure it succeeds. From testing this a handful of times, on my machine it succeeds either at first or second try.