### PR TITLE
Use different case in PlatformFile[Mm]anager.h include based on engine version

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -10,9 +10,14 @@
 #include "GitSourceControlPrivatePCH.h"
 #include "GitSourceControlProvider.h"
 #include "HAL/PlatformProcess.h"
+
+#if ( ENGINE_MAJOR_VERSION == 5 )
 #include "HAL/PlatformFileManager.h"
-#include "HAL/FileManager.h"
+#else
 #include "HAL/PlatformFilemanager.h"
+#endif
+
+#include "HAL/FileManager.h"
 #include "HAL/PlatformProcess.h"
 #include "Interfaces/IPluginManager.h"
 #include "ISourceControlModule.h"


### PR DESCRIPTION
UE5 branches (ue5-main, 5.0, etc) renamed HAL/PlatformFilemanager.h to have proper case, and Linux is picky about filename case.