### PR TITLE
Use git.exe and lfs as a sub-command.

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -667,7 +667,7 @@ bool RunLFSCommand(const FString& InCommand, const FString& InRepositoryRoot, co
 	checkf(false, TEXT("Unhandled platform for LFS binary!"));
 #endif
 
-	return GitSourceControlUtils::RunCommand(InCommand, LFSLockBinary, InRepositoryRoot, InParameters, InFiles, OutResults, OutErrorMessages);
+	return GitSourceControlUtils::RunCommand(TEXT("lfs ") + InCommand, GitSourceControlUtils::FindGitBinaryPath(), InRepositoryRoot, InParameters, InFiles, OutResults, OutErrorMessages);
 }
 
 // Run a Git "commit" command by batches

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -656,17 +656,6 @@ bool RunCommand(const FString& InCommand, const FString& InPathToGitBinary, cons
 bool RunLFSCommand(const FString& InCommand, const FString& InRepositoryRoot, const TArray<FString>& InParameters, const TArray<FString>& InFiles,
 				   TArray<FString>& OutResults, TArray<FString>& OutErrorMessages)
 {
-	FString BaseDir = IPluginManager::Get().FindPlugin("GitSourceControl")->GetBaseDir();
-#if PLATFORM_WINDOWS
-	FString LFSLockBinary = FString::Printf(TEXT("%s/git-lfs.exe"), *BaseDir);
-#elif PLATFORM_MAC
-	FString LFSLockBinary = FString::Printf(TEXT("%s/git-lfs-mac"), *BaseDir);
-#elif PLATFORM_LINUX
-	FString LFSLockBinary = FString::Printf(TEXT("%s/git-lfs"), *BaseDir);
-#else
-	checkf(false, TEXT("Unhandled platform for LFS binary!"));
-#endif
-
 	return GitSourceControlUtils::RunCommand(TEXT("lfs ") + InCommand, GitSourceControlUtils::FindGitBinaryPath(), InRepositoryRoot, InParameters, InFiles, OutResults, OutErrorMessages);
 }
 


### PR DESCRIPTION
The embedded git-lfs.exe process gets stuck at shutdown so the thread never closes, therefore the UnrealEditor process gets stuck too.