### PR TITLE
add additional whitelisting in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 Binaries/
 /Intermediate
 .DS_Store
-!git-lfs.exe
+
+### whitelisted files
 !Resources/*
 !Screenshots/*
+!git-lfs.exe
+!git-lfs
+!git-lfs-mac-amd64
+!git-lfs-mac-arm64

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 Binaries/
 /Intermediate
 .DS_Store
+!git-lfs.exe
+!Resources/*
+!Screenshots/*


### PR DESCRIPTION
i am proposing this change to assist the installation process in project scope. 

especially when user trying to add ue git plugin inside the project to ease distribution.  since recommended `.gitignore` of pbcore ignores git-lfs.exe files which required by the plugin to works