### PR TITLE
Adding submodule support beyond Plugins

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -86,29 +86,26 @@ namespace GitSourceControlUtils
 	FString ChangeRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot)
 	{
 		FString Ret = PathToRepositoryRoot;
-		FString PluginsRoot = FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir());
-		// note this is not going to support operations where selected files are both in the root repo and the submodule/plugin's repo
-		int NumPluginFiles = 0;
+		// note this is not going to support operations where selected files are in different repositories
 
 		for (auto& FilePath : AbsoluteFilePaths)
 		{
-			if (!FilePath.Contains(PluginsRoot))
+			FString TestPath = FilePath;
+			while (!FPaths::IsSamePath(TestPath, PathToRepositoryRoot))
 			{
-				return PathToRepositoryRoot;
-			}
-
-			FString PluginPart = FilePath.Replace(*PluginsRoot, *FString(""));
-			PluginPart = PluginPart.Left(PluginPart.Find("/"));
-			FString CandidateRepoRoot = PluginsRoot + PluginPart;
-			FString IsItUsingGitPath = CandidateRepoRoot + "/.git";
-			if (FPaths::FileExists(IsItUsingGitPath) || FPaths::DirectoryExists(IsItUsingGitPath))
-			{
-				if (Ret != PathToRepositoryRoot && Ret != CandidateRepoRoot)
+				// Iterating over path directories, looking for .git
+				TestPath = FPaths::GetPath(TestPath);
+				FString GitTestPath = TestPath + "/.git";
+				if (FPaths::FileExists(GitTestPath) || FPaths::DirectoryExists(GitTestPath))
 				{
-					UE_LOG(LogSourceControl, Error, TEXT("Selected files belong to different submodules"));
-					return PathToRepositoryRoot;
+					if (Ret != PathToRepositoryRoot && Ret != GitTestPath)
+					{
+						UE_LOG(LogSourceControl, Error, TEXT("Selected files belong to different submodules"));
+						return PathToRepositoryRoot;
+					}
+					Ret = TestPath;
+					break;
 				}
-				Ret = CandidateRepoRoot;
 			}
 		}
 		return Ret;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -92,26 +92,22 @@ namespace GitSourceControlUtils
 
 		for (auto& FilePath : AbsoluteFilePaths)
 		{
-			if (FilePath.Contains(PluginsRoot))
+			if (!FilePath.Contains(PluginsRoot))
 			{
-				NumPluginFiles++;
+				return PathToRepositoryRoot;
 			}
-		}
-		// if all plugins?
-		// modify Source control base path
-		if ((NumPluginFiles == AbsoluteFilePaths.Num()) && (AbsoluteFilePaths.Num() > 0))
-		{
-			FString FullPath = AbsoluteFilePaths[0];
 
-			FString PluginPart = FullPath.Replace(*PluginsRoot, *FString(""));
+			FString PluginPart = FilePath.Replace(*PluginsRoot, *FString(""));
 			PluginPart = PluginPart.Left(PluginPart.Find("/"));
-
-
 			FString CandidateRepoRoot = PluginsRoot + PluginPart;
-
 			FString IsItUsingGitPath = CandidateRepoRoot + "/.git";
 			if (FPaths::FileExists(IsItUsingGitPath) || FPaths::DirectoryExists(IsItUsingGitPath))
 			{
+				if (Ret != PathToRepositoryRoot && Ret != CandidateRepoRoot)
+				{
+					UE_LOG(LogSourceControl, Error, TEXT("Selected files belong to different submodules"));
+					return PathToRepositoryRoot;
+				}
 				Ret = CandidateRepoRoot;
 			}
 		}


### PR DESCRIPTION
I just discovered #75 this morning, and @Louspirit did an amazing job here.

This very small PR is just an extension of their work to support submodules anywhere in the root repository, not just for `Plugins`. It could be argued that supporting submodules beyond `Plugins` gets into weird territory and niche use cases, but I know for my case I'm using them for Marketplace products (both for cross-project reuse and creator updates tracking).

One of the two commit actually is a fix on the previous implementation, which assumed that all selected files belonged to the same repository.

Thanks to all contributors and maintainers for this project!