### PR TITLE
Misc improvements

### DIFF
--- a/.gitbugtraq
+++ b/.gitbugtraq
@@ -1,7 +1,0 @@
-# .gitbugtraq for Git GUIs (SmartGit/TortoiseGit) to show links to the Github issue tracker.
-# Instead of the repository root directory, it could be added as an additional section to $GIT_DIR/config.
-# (note that '\' need to be escaped).
-[bugtraq]
-  url = https://github.com/SRombauts/UE4GitPlugin/issues/%BUGID%
-  loglinkregex = "#\\d+"
-  logregex = \\d+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# PBGet
+Binaries/
+/Intermediate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-# PBGet
-Binaries/
-/Intermediate

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -133,14 +133,16 @@ bool FGitCheckOutWorker::Execute(FGitSourceControlCommand& InCommand)
 		for (const auto& RelativeFile : RelativeFiles)
 		{
 			FString AbsoluteFile = FPaths::Combine(InCommand.PathToGitRoot, RelativeFile);
-			FGitLockedFilesCache::LockedFiles.Add(AbsoluteFile, LockUser);
+		// WCA EDIT - BEGIN
+			FGitLockedFilesCache::AddLockedFile(AbsoluteFile, LockUser);
 			FPaths::NormalizeFilename(AbsoluteFile);
 			AbsoluteFiles.Add(AbsoluteFile);
 		}
-		for (const auto& File : AbsoluteFiles)
+		/*for (const auto& File : AbsoluteFiles)
 		{
 			FPlatformFileManager::Get().GetPlatformFile().SetReadOnly(*File, false);
-		}
+		}*/
+		// WCA EDIT - END
 		GitSourceControlUtils::CollectNewStates(AbsoluteFiles, States, EFileState::Unset, ETreeState::Unset, ELockState::Locked);
 		for (auto& State : States)
 		{
@@ -345,7 +347,9 @@ bool FGitCheckInWorker::Execute(FGitSourceControlCommand& InCommand)
 						{
 							for (const auto& File : LockedFiles)
 							{
-								FGitLockedFilesCache::LockedFiles.Remove(File);
+								// WCA EDIT - BEGIN
+								FGitLockedFilesCache::RemoveLockedFile(File);
+								// WCA EDIT - END
 							}
 						}
 					}
@@ -584,7 +588,9 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 			{
 				for (const auto& File : LockedFiles)
 				{
-					FGitLockedFilesCache::LockedFiles.Remove(File);
+					// WCA EDIT - BEGIN
+					FGitLockedFilesCache::RemoveLockedFile(File);
+					// WCA EDIT - END
 				}
 			}
 		}

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -133,16 +133,11 @@ bool FGitCheckOutWorker::Execute(FGitSourceControlCommand& InCommand)
 		for (const auto& RelativeFile : RelativeFiles)
 		{
 			FString AbsoluteFile = FPaths::Combine(InCommand.PathToGitRoot, RelativeFile);
-		// WCA EDIT - BEGIN
 			FGitLockedFilesCache::AddLockedFile(AbsoluteFile, LockUser);
 			FPaths::NormalizeFilename(AbsoluteFile);
 			AbsoluteFiles.Add(AbsoluteFile);
 		}
-		/*for (const auto& File : AbsoluteFiles)
-		{
-			FPlatformFileManager::Get().GetPlatformFile().SetReadOnly(*File, false);
-		}*/
-		// WCA EDIT - END
+
 		GitSourceControlUtils::CollectNewStates(AbsoluteFiles, States, EFileState::Unset, ETreeState::Unset, ELockState::Locked);
 		for (auto& State : States)
 		{
@@ -347,9 +342,7 @@ bool FGitCheckInWorker::Execute(FGitSourceControlCommand& InCommand)
 						{
 							for (const auto& File : LockedFiles)
 							{
-								// WCA EDIT - BEGIN
 								FGitLockedFilesCache::RemoveLockedFile(File);
-								// WCA EDIT - END
 							}
 						}
 					}
@@ -588,9 +581,7 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 			{
 				for (const auto& File : LockedFiles)
 				{
-					// WCA EDIT - BEGIN
 					FGitLockedFilesCache::RemoveLockedFile(File);
-					// WCA EDIT - END
 				}
 			}
 		}

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -838,7 +838,6 @@ int32 FGitSourceControlProvider::GetStateBranchIndex(const FString& StateBranchN
 	return StatusBranchNames.IndexOfByKey(StateBranchName);
 }
 
-// WCA EDIT - BEGIN
 TArray<FString> FGitSourceControlProvider::GetStatusBranchNames() const
 {
 	TArray<FString> StatusBranches;
@@ -860,6 +859,5 @@ TArray<FString> FGitSourceControlProvider::GetStatusBranchNames() const
 	
 	return StatusBranches;
 }
-// WCA EDIT - END
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.h
@@ -203,9 +203,7 @@ public:
 
 	const FString& GetRemoteBranchName() const { return RemoteBranchName; }
 
-	// WCA EDIT - BEGIN
 	TArray<FString> GetStatusBranchNames() const;
-	// WCA EDIT - END
 	
 	/** Indicates editor binaries are to be updated upon next sync */
 	bool bPendingRestart;
@@ -299,10 +297,8 @@ private:
 	*/
 	TArray<FString> IgnoreForceCache;
 
-	// WCA EDIT - BEGIN
 	/** Array of branch name patterns for status queries */
 	TArray<FString> StatusBranchNamePatternsInternal;
-	// WCA EDIT - END
 		
 	class FGitSourceControlRunner* Runner = nullptr;
 };

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.h
@@ -194,11 +194,10 @@ public:
 
 	const FString& GetRemoteBranchName() const { return RemoteBranchName; }
 
-	const TArray<FString>& GetStatusBranchNames() const
-	{
-		return StatusBranchNames;
-	}
-
+	// WCA EDIT - BEGIN
+	TArray<FString> GetStatusBranchNames() const;
+	// WCA EDIT - END
+	
 	/** Indicates editor binaries are to be updated upon next sync */
 	bool bPendingRestart;
 
@@ -291,8 +290,10 @@ private:
 	*/
 	TArray<FString> IgnoreForceCache;
 
-	/** Array of branch names for status queries */
-	TArray<FString> StatusBranchNames;
-
+	// WCA EDIT - BEGIN
+	/** Array of branch name patterns for status queries */
+	TArray<FString> StatusBranchNamePatternsInternal;
+	// WCA EDIT - END
+		
 	class FGitSourceControlRunner* Runner = nullptr;
 };

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -133,7 +133,10 @@ bool RunCommandInternalRaw(const FString& InCommand, const FString& InPathToGitB
 	UE_LOG(LogSourceControl, Log, TEXT("RunCommand: 'git %s'"), *LogableCommand);
 #endif
 
+	// WCA EDIT - BEGIN
+	//const FString& PathToGitOrEnvBinary = InPathToGitBinary;
 	FString PathToGitOrEnvBinary = InPathToGitBinary;
+	// WCA EDIT - END
 #if PLATFORM_MAC
 	// The Cocoa application does not inherit shell environment variables, so add the path expected to have git-lfs to PATH
 	FString PathEnv = FPlatformMisc::GetEnvironmentVariable(TEXT("PATH"));

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -81,7 +81,6 @@ const FString& FGitScopedTempFile::GetFilename() const
 FDateTime FGitLockedFilesCache::LastUpdated = FDateTime::MinValue();
 TMap<FString, FString> FGitLockedFilesCache::LockedFiles = TMap<FString, FString>();
 
-// WCA EDIT - BEGIN
 void FGitLockedFilesCache::SetLockedFiles(const TMap<FString, FString>& newLocks)
 {	
 	for (auto lock : LockedFiles)
@@ -124,8 +123,6 @@ void FGitLockedFilesCache::OnFileLockChanged(const FString& filePath, const FStr
 		FPlatformFileManager::Get().GetPlatformFile().SetReadOnly(*filePath, !locked);		
 	}
 }
-
-// WCA EDIT - END
 
 namespace GitSourceControlUtils
 {
@@ -221,10 +218,7 @@ bool RunCommandInternalRaw(const FString& InCommand, const FString& InPathToGitB
 	UE_LOG(LogSourceControl, Log, TEXT("RunCommand: 'git %s'"), *LogableCommand);
 #endif
 
-	// WCA EDIT - BEGIN
-	//const FString& PathToGitOrEnvBinary = InPathToGitBinary;
 	FString PathToGitOrEnvBinary = InPathToGitBinary;
-	// WCA EDIT - END
 #if PLATFORM_MAC
 	// The Cocoa application does not inherit shell environment variables, so add the path expected to have git-lfs to PATH
 	FString PathEnv = FPlatformMisc::GetEnvironmentVariable(TEXT("PATH"));
@@ -688,7 +682,6 @@ bool GetRemoteBranchName(const FString& InPathToGitBinary, const FString& InRepo
 	return bResults;
 }
 
-// WCA EDIT - BEGIN
 bool GetRemoteBranchesWildcard(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const FString& PatternMatch, TArray<FString>& OutBranchNames)
 {
 	TArray<FString> InfoMessages;
@@ -713,7 +706,6 @@ bool GetRemoteBranchesWildcard(const FString& InPathToGitBinary, const FString& 
 	}
 	return bResults;	
 }
-// WCA EDIT - END
 	
 bool GetCommitInfo(const FString& InPathToGitBinary, const FString& InRepositoryRoot, FString& OutCommitId, FString& OutCommitSummary)
 {
@@ -1409,9 +1401,7 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	// Get the full remote status of the Content folder, since it's the only lockable folder we track in editor. 
 	// This shows any new files as well.
 	// Also update the status of `.checksum`.
-	// WCA EDIT - BEGIN - also include binaries and plugins
 	TArray<FString> FilesToDiff{FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()), ".checksum", "Binaries/", "Plugins/"};
-	// WCA EDIT - END
 	TArray<FString> ParametersLog{TEXT("--pretty="), TEXT("--name-only"), TEXT(""), TEXT("--")};
 	for (auto& Branch : BranchesToDiff)
 	{
@@ -1436,14 +1426,12 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 				// Don't care about mergeable files (.collection, .ini, .uproject, etc)
 				if (!IsFileLFSLockable(NewerFileName))
 				{
-					// WCA EDIT - BEGIN - also include binaries and plugins
 					// Check if there's newer binaries pending on this branch
 					if (bCurrentBranch && (NewerFileName == TEXT(".checksum") || NewerFileName.StartsWith("Binaries/", ESearchCase::IgnoreCase) ||
 						NewerFileName.StartsWith("Plugins/", ESearchCase::IgnoreCase)))
 					{
 						Provider.bPendingRestart = true;
 					}
-					// WCA EDIT - END
 					continue;
 				}
 				const FString& NewerFilePath = FPaths::ConvertRelativePathToFull(InRepositoryRoot, NewerFileName);
@@ -1506,9 +1494,7 @@ bool GetAllLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallba
 				OutLocks.Add(MoveTemp(LockFile.LocalFilename), MoveTemp(LockFile.LockUser));
 			}
 			FGitLockedFilesCache::LastUpdated = CurrentTime;
-			// WCA EDIT - BEGIN
 			FGitLockedFilesCache::SetLockedFiles(OutLocks);
-			// WCA EDIT - END
 			return bResult;
 		}
 		// We tried to invalidate the UE cache, but we failed for some reason. Try updating lock state from LFS cache.
@@ -2237,12 +2223,9 @@ bool FetchRemote(const FString& InPathToGitBinary, const FString& InPathToReposi
 	// fetch latest repo
 	// TODO specify branches?
 
-	// WCA EDIT - BEGIN
 	Params.Add(TEXT("--prune"));
 	return RunCommand(TEXT("fetch"), InPathToGitBinary, InPathToRepositoryRoot, Params,
 					  FGitSourceControlModule::GetEmptyStringArray(), OutResults, OutErrorMessages);
-	// WCA EDIT - END
-
 }
 
 bool PullOrigin(const FString& InPathToGitBinary, const FString& InPathToRepositoryRoot, const TArray<FString>& InFiles, TArray<FString>& OutFiles,

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -38,7 +38,18 @@ class FGitLockedFilesCache
 {
 public:
 	static FDateTime LastUpdated;
+
+ // WCA EDIT - BEGIN
+ static const TMap<FString, FString>& GetLockedFiles() { return LockedFiles; }
+ static void SetLockedFiles(const TMap<FString, FString>& newLocks);
+ static void AddLockedFile(const FString& filePath, const FString& lockUser);
+ static void RemoveLockedFile(const FString& filePath);
+
+private:
+ static void OnFileLockChanged(const FString& filePath, const FString& lockUser, bool locked);
+ // update local read/write state when our own lock statuses change
 	static TMap<FString, FString> LockedFiles;
+ // WCA EDIT - END
 };
 
 namespace GitSourceControlUtils

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -111,6 +111,14 @@ bool GetBranchName(const FString& InPathToGitBinary, const FString& InRepository
  */
 bool GetRemoteBranchName(const FString& InPathToGitBinary, const FString& InRepositoryRoot, FString& OutBranchName);
 
+ // WCA EDIT - BEGIN
+ /**
+ * Get Git remote tracking branches that match wildcard
+ * @returns false if no matching branches
+ */
+ bool GetRemoteBranchesWildcard(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const FString& PatternMatch, TArray<FString>& OutBranchNames);
+ // WCA EDIT - END
+ 
 /**
  * Get Git current commit details
  * @param	InPathToGitBinary	The path to the Git binary

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -39,7 +39,6 @@ class FGitLockedFilesCache
 public:
 	static FDateTime LastUpdated;
 
- // WCA EDIT - BEGIN
  static const TMap<FString, FString>& GetLockedFiles() { return LockedFiles; }
  static void SetLockedFiles(const TMap<FString, FString>& newLocks);
  static void AddLockedFile(const FString& filePath, const FString& lockUser);
@@ -49,7 +48,6 @@ private:
  static void OnFileLockChanged(const FString& filePath, const FString& lockUser, bool locked);
  // update local read/write state when our own lock statuses change
 	static TMap<FString, FString> LockedFiles;
- // WCA EDIT - END
 };
 
 namespace GitSourceControlUtils
@@ -139,13 +137,11 @@ bool GetBranchName(const FString& InPathToGitBinary, const FString& InRepository
  */
 bool GetRemoteBranchName(const FString& InPathToGitBinary, const FString& InRepositoryRoot, FString& OutBranchName);
 
- // WCA EDIT - BEGIN
  /**
  * Get Git remote tracking branches that match wildcard
  * @returns false if no matching branches
  */
  bool GetRemoteBranchesWildcard(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const FString& PatternMatch, TArray<FString>& OutBranchNames);
- // WCA EDIT - END
  
 /**
  * Get Git current commit details


### PR DESCRIPTION
1. Support status branch patterns (e.g. "release/*")
2. Force restart the editor when Plugins/ binary changes detected
3. Bugfix: read-only file attribute gets out of sync with LFS lock status