### PR TITLE
Fix non-unity and UE 5.2 compilation errors

### DIFF
--- a/Source/GitSourceControl/Private/GitMessageLog.h
+++ b/Source/GitSourceControl/Private/GitMessageLog.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "ISourceControlModule.h"
 #include "Internationalization/Text.h"
 #include "Logging/MessageLog.h"
 #include "Logging/TokenizedMessage.h"

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -38,6 +38,8 @@
 #include "ToolMenuMisc.h"
 #endif
 
+#include "UObject/Linker.h"
+
 static const FName GitSourceControlMenuTabName(TEXT("GitSourceControlMenu"));
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -23,6 +23,8 @@
 #include "ISourceControlModule.h"
 #include "SourceControlHelpers.h"
 #include "Framework/Commands/UIAction.h"
+#include "Framework/MultiBox/MultiBoxExtender.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"
 

--- a/Source/GitSourceControl/Private/GitSourceControlModule.h
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.h
@@ -12,6 +12,7 @@
 #include "GitSourceControlProvider.h"
 
 struct FAssetData;
+class FExtender;
 
 /**
 

--- a/Source/GitSourceControl/Private/GitSourceControlState.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlState.cpp
@@ -6,7 +6,7 @@
 #include "GitSourceControlState.h"
 
 #if ENGINE_MAJOR_VERSION >= 5
-include "Textures/SlateIcon.h"
+#include "Textures/SlateIcon.h"
 #if ENGINE_MINOR_VERSION >= 2
 #include "RevisionControlStyle/RevisionControlStyle.h"
 #endif
@@ -97,13 +97,13 @@ FSlateIcon FGitSourceControlState::GetIcon() const
 #endif
 	case EGitState::LockedOther:
 #if ENGINE_MINOR_VERSION >= 2
-		return GET_ICON_RETURN("RevisionControl.CheckedOutByOtherUser", NAME_None, "RevisionControl.CheckedOutByOtherUserBadge");
+		return GET_ICON_RETURN("RevisionControl.CheckedOutByOtherUser");
 #else
 		return GET_ICON_RETURN("Perforce.CheckedOutByOtherUser");
 #endif
 	case EGitState::NotLatest:
 #if ENGINE_MINOR_VERSION >= 2
-		return GET_ICON_RETURN("RevisionControl.ModifiedOtherBranch", NAME_None, "RevisionControl.ModifiedBadge");
+		return GET_ICON_RETURN("RevisionControl.ModifiedOtherBranch");
 #else
 		return GET_ICON_RETURN("Perforce.ModifiedOtherBranch");
 #endif

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -35,6 +35,7 @@
 #include "Misc/MessageDialog.h"
 
 #include "Async/Async.h"
+#include "UObject/Linker.h"
 
 #ifndef GIT_DEBUG_STATUS
 #define GIT_DEBUG_STATUS 0

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "GitSourceControlRevision.h"
+#include "GitSourceControlState.h"
 
 class FGitSourceControlState;
 


### PR DESCRIPTION
I'm not 100% sure that these changes are valid for previous versions of the engine, and I can't verify this at the moment, so additional checks are welcome.