### PR TITLE
Resolve compiler errors for clang on Linux

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -142,7 +142,8 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 		return;
 	}
 	
-	const FString& BranchName = FGitSourceControlModule::Get().GetProvider().GetStatusBranchNames()[0];
+	const TArray<FString>& StatusBranchNames = FGitSourceControlModule::Get().GetProvider().GetStatusBranchNames();
+	const FString& BranchName = StatusBranchNames[0];
 	MenuBuilder.AddMenuEntry(
 		FText::Format(LOCTEXT("StatusBranchDiff", "Diff against status branch"), FText::FromString(BranchName)),
 		FText::Format(LOCTEXT("StatusBranchDiffDesc", "Compare this asset to the latest status branch version"), FText::FromString(BranchName)),

--- a/Source/GitSourceControl/Private/SGitSourceControlSettings.h
+++ b/Source/GitSourceControl/Private/SGitSourceControlSettings.h
@@ -9,7 +9,11 @@
 #include "ISourceControlProvider.h"
 
 class SNotificationItem;
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 2
 namespace ETextCommit { enum Type : int; }
+#else
+namespace ETextCommit { enum Type; }
+#endif
 
 enum class ECheckBoxState : uint8;
 


### PR DESCRIPTION
These two problems seem to only effect Linux (and maybe macOS, I don't have one). I'm unsure why Windows with MSVC doesn't complain about the dangling pointer or non-fixed type. I wasn't sure if platform-specific compile flags were necessary since I see no reason why the same syntax would result in a dangling pointer on only one platform. Happy to add them if there's any concern.