### PR TITLE
Fix occasional "Selected files belong to different submodules" error

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -145,7 +145,11 @@ namespace GitSourceControlUtils
 				FString GitTestPath = TestPath + "/.git";
 				if (FPaths::FileExists(GitTestPath) || FPaths::DirectoryExists(GitTestPath))
 				{
-					if (Ret != PathToRepositoryRoot && Ret != GitTestPath)
+					FString RetNormalized = Ret;
+					FPaths::NormalizeDirectoryName(RetNormalized);
+					FString PathToRepositoryRootNormalized = PathToRepositoryRoot;
+					FPaths::NormalizeDirectoryName(PathToRepositoryRootNormalized);
+					if (!FPaths::IsSamePath(RetNormalized, PathToRepositoryRootNormalized) && Ret != GitTestPath)
 					{
 						UE_LOG(LogSourceControl, Error, TEXT("Selected files belong to different submodules"));
 						return PathToRepositoryRoot;


### PR DESCRIPTION
The issue is that the paths being compared aren't normalized so one may have trailing slash while the other doesn't.