### PR TITLE
Fix implicit `this` in `FGitSourceControlRunner`

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlRunner.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlRunner.cpp
@@ -45,7 +45,7 @@ uint32 FGitSourceControlRunner::Run()
 		{
 			// Flag that we're running the task already
 			bRefreshSpawned = true;
-			const auto ExecuteResult = Async(EAsyncExecution::TaskGraphMainThread, [=] {
+			const auto ExecuteResult = Async(EAsyncExecution::TaskGraphMainThread, [this] {
 				FGitSourceControlModule* GitSourceControl = FGitSourceControlModule::GetThreadSafe();
 				// Module not loaded, bail. Usually happens when editor is shutting down, and this prevents a crash from bad timing.
 				if (!GitSourceControl)


### PR DESCRIPTION
We get an error on cpp20 and this fixes that, but it should also still work on older versions. If this is wrong, let me know and I'll correct it since I don't have the opportunity to test with the older versions.