### PR TITLE
Implement intuitive ofpa staging/unstaging by diverting Changelist

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
@@ -1,4 +1,4 @@
 ﻿#include "GitSourceControlChangelist.h"
 
-const FGitSourceControlChangelist FGitSourceControlChangelist::WorkingChangelist(TEXT("Working"), true);
-const FGitSourceControlChangelist FGitSourceControlChangelist::StagedChangelist(TEXT("Staged"), true);
+FGitSourceControlChangelist FGitSourceControlChangelist::WorkingChangelist(TEXT("Working"), true);
+FGitSourceControlChangelist FGitSourceControlChangelist::StagedChangelist(TEXT("Staged"), true);

--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
@@ -1,3 +1,4 @@
 ﻿#include "GitSourceControlChangelist.h"
 
-const FGitSourceControlChangelist FGitSourceControlChangelist::DefaultChangelist(TEXT("Working"), true);
+const FGitSourceControlChangelist FGitSourceControlChangelist::WorkingChangelist(TEXT("Working"), true);
+const FGitSourceControlChangelist FGitSourceControlChangelist::StagedChangelist(TEXT("Staged"), true);

--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
@@ -1,0 +1,3 @@
+﻿#include "GitSourceControlChangelist.h"
+
+const FGitSourceControlChangelist FGitSourceControlChangelist::DefaultChangelist(TEXT("Working"), true);

--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.h
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.h
@@ -64,8 +64,8 @@ public:
 	}
 
 public:
-	static const FGitSourceControlChangelist WorkingChangelist;
-	static const FGitSourceControlChangelist StagedChangelist;
+	static FGitSourceControlChangelist WorkingChangelist;
+	static FGitSourceControlChangelist StagedChangelist;
 
 private:
 	FString ChangelistName;

--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.h
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.h
@@ -14,7 +14,7 @@ public:
 
 	virtual bool CanDelete() const override
 	{
-		return !IsDefault();
+		return false;
 	}
 
 	bool operator==(const FGitSourceControlChangelist& InOther) const
@@ -29,7 +29,7 @@ public:
 
 	virtual bool IsDefault() const override
 	{
-		return ChangelistName == DefaultChangelist.ChangelistName;
+		return ChangelistName == WorkingChangelist.ChangelistName;
 	}
 
 	void SetInitialized()
@@ -64,7 +64,8 @@ public:
 	}
 
 public:
-	static const FGitSourceControlChangelist DefaultChangelist;
+	static const FGitSourceControlChangelist WorkingChangelist;
+	static const FGitSourceControlChangelist StagedChangelist;
 
 private:
 	FString ChangelistName;
@@ -72,4 +73,3 @@ private:
 };
 
 typedef TSharedRef<class FGitSourceControlChangelist, ESPMode::ThreadSafe> FGitSourceControlChangelistRef;
-};

--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.h
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.h
@@ -1,0 +1,75 @@
+﻿#pragma once
+#include "ISourceControlChangelist.h"
+
+class FGitSourceControlChangelist : public ISourceControlChangelist
+{
+public:
+	FGitSourceControlChangelist() = default;
+
+	explicit FGitSourceControlChangelist(FString&& InChangelistName, const bool bInInitialized = false)
+		: ChangelistName(MoveTemp(InChangelistName))
+		  , bInitialized(bInInitialized)
+	{
+	}
+
+	virtual bool CanDelete() const override
+	{
+		return !IsDefault();
+	}
+
+	bool operator==(const FGitSourceControlChangelist& InOther) const
+	{
+		return ChangelistName == InOther.ChangelistName;
+	}
+
+	bool operator!=(const FGitSourceControlChangelist& InOther) const
+	{
+		return ChangelistName != InOther.ChangelistName;
+	}
+
+	virtual bool IsDefault() const override
+	{
+		return ChangelistName == DefaultChangelist.ChangelistName;
+	}
+
+	void SetInitialized()
+	{
+		bInitialized = true;
+	}
+
+	bool IsInitialized() const
+	{
+		return bInitialized;
+	}
+
+	void Reset()
+	{
+		ChangelistName.Reset();
+		bInitialized = false;
+	}
+
+	friend FORCEINLINE uint32 GetTypeHash(const FGitSourceControlChangelist& InGitChangelist)
+	{
+		return GetTypeHash(InGitChangelist.ChangelistName);
+	}
+
+	FString GetName() const
+	{
+		return ChangelistName;
+	}
+
+	virtual FString GetIdentifier() const override
+	{
+		return ChangelistName;
+	}
+
+public:
+	static const FGitSourceControlChangelist DefaultChangelist;
+
+private:
+	FString ChangelistName;
+	bool bInitialized = false;
+};
+
+typedef TSharedRef<class FGitSourceControlChangelist, ESPMode::ThreadSafe> FGitSourceControlChangelistRef;
+};

--- a/Source/GitSourceControl/Private/GitSourceControlChangelistState.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelistState.cpp
@@ -1,0 +1,47 @@
+﻿#include "GitSourceControlChangelistState.h"
+
+#define LOCTEXT_NAMESPACE "GitSourceControl.ChangelistState"
+
+FName FGitSourceControlChangelistState::GetIconName() const
+{
+	// Mimic P4V colors, returning the red icon if there are active file(s), the blue if the changelist is empty or all the files are shelved.
+	return FName("SourceControl.Changelist");
+}
+
+FName FGitSourceControlChangelistState::GetSmallIconName() const
+{
+	return GetIconName();
+}
+
+FText FGitSourceControlChangelistState::GetDisplayText() const
+{
+	return FText::FromString(Changelist.GetName());
+}
+
+FText FGitSourceControlChangelistState::GetDescriptionText() const
+{
+	return FText::FromString(Description);
+}
+
+FText FGitSourceControlChangelistState::GetDisplayTooltip() const
+{
+	return LOCTEXT("Tooltip", "Tooltip");
+}
+
+const FDateTime& FGitSourceControlChangelistState::GetTimeStamp() const
+{
+	return TimeStamp;
+}
+
+const TArray<FSourceControlStateRef>& FGitSourceControlChangelistState::GetFilesStates() const
+{
+	return Files;
+}
+
+FSourceControlChangelistRef FGitSourceControlChangelistState::GetChangelist() const
+{
+	FGitSourceControlChangelistRef ChangelistCopy = MakeShareable( new FGitSourceControlChangelist(Changelist));
+	return StaticCastSharedRef<ISourceControlChangelist>(ChangelistCopy);
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlChangelistState.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelistState.cpp
@@ -38,6 +38,11 @@ const TArray<FSourceControlStateRef>& FGitSourceControlChangelistState::GetFiles
 	return Files;
 }
 
+const TArray<FSourceControlStateRef>& FGitSourceControlChangelistState::GetShelvedFilesStates() const
+{
+	return ShelvedFiles;
+}
+
 FSourceControlChangelistRef FGitSourceControlChangelistState::GetChangelist() const
 {
 	FGitSourceControlChangelistRef ChangelistCopy = MakeShareable( new FGitSourceControlChangelist(Changelist));

--- a/Source/GitSourceControl/Private/GitSourceControlChangelistState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelistState.h
@@ -57,6 +57,8 @@ public:
 	virtual const FDateTime& GetTimeStamp() const override;
 
 	virtual const TArray<FSourceControlStateRef>& GetFilesStates() const override;
+	
+	virtual const TArray<FSourceControlStateRef>& GetShelvedFilesStates() const override;
 
 	virtual FSourceControlChangelistRef GetChangelist() const override;
 
@@ -66,6 +68,8 @@ public:
 	FString Description;
 
 	TArray<FSourceControlStateRef> Files;
+	
+	TArray<FSourceControlStateRef> ShelvedFiles;
 
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;

--- a/Source/GitSourceControl/Private/GitSourceControlChangelistState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelistState.h
@@ -1,0 +1,72 @@
+﻿#pragma once
+#include "GitSourceControlChangelist.h"
+#include "ISourceControlChangelistState.h"
+#include "ISourceControlState.h"
+
+class FGitSourceControlChangelistState : public ISourceControlChangelistState
+{
+public:
+	explicit FGitSourceControlChangelistState(const FGitSourceControlChangelist& InChangelist,
+	                                              const FString& InDescription = FString())
+		: Changelist(InChangelist)
+		  , Description(InDescription)
+	{
+	}
+
+	explicit FGitSourceControlChangelistState(FGitSourceControlChangelist&& InChangelist,
+	                                              FString&& InDescription)
+		: Changelist(MoveTemp(InChangelist))
+		  , Description(MoveTemp(InDescription))
+	{
+	}
+
+	/**
+	 * Get the name of the icon graphic we should use to display the state in a UI.
+	 * @returns the name of the icon to display
+	 */
+	virtual FName GetIconName() const override;
+
+	/**
+	 * Get the name of the small icon graphic we should use to display the state in a UI.
+	 * @returns the name of the icon to display
+	 */
+	virtual FName GetSmallIconName() const override;
+
+	/**
+	 * Get a text representation of the state
+	 * @returns	the text to display for this state
+	 */
+	virtual FText GetDisplayText() const override;
+
+	/**
+	 * Get a text representation of the state
+	 * @returns	the text to display for this state
+	 */
+	virtual FText GetDescriptionText() const override;
+
+	/**
+	 * Get a tooltip to describe this state
+	 * @returns	the text to display for this states tooltip
+	 */
+	virtual FText GetDisplayTooltip() const override;
+
+	/**
+	 * Get the timestamp of the last update that was made to this state.
+	 * @returns	the timestamp of the last update
+	 */
+	virtual const FDateTime& GetTimeStamp() const override;
+
+	virtual const TArray<FSourceControlStateRef>& GetFilesStates() const override;
+
+	virtual FSourceControlChangelistRef GetChangelist() const override;
+
+public:
+	FGitSourceControlChangelist Changelist;
+
+	FString Description;
+
+	TArray<FSourceControlStateRef> Files;
+
+	/** The timestamp of the last update */
+	FDateTime TimeStamp;
+};

--- a/Source/GitSourceControl/Private/GitSourceControlCommand.h
+++ b/Source/GitSourceControl/Private/GitSourceControlCommand.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "GitSourceControlChangelist.h"
 #include "ISourceControlProvider.h"
 #include "Misc/IQueuedWork.h"
 
@@ -115,6 +116,9 @@ public:
 
 	/** Files to perform this operation on */
 	TArray<FString> Files;
+
+	/** Changelist to perform this operation on */
+	FGitSourceControlChangelist Changelist;
 
 	/** Potential error, warning and info message storage */
 	FGitSourceControlResultInfo ResultInfo;

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -51,6 +51,7 @@ void FGitSourceControlModule::StartupModule()
 	GitSourceControlProvider.RegisterWorker( "CheckIn", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitCheckInWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "Copy", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitCopyWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "Resolve", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitResolveWorker> ) );
+	GitSourceControlProvider.RegisterWorker( "MoveToChangelist", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitMoveToChangelistWorker> ) );
 
 	// load our settings
 	GitSourceControlSettings.LoadSettings();

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -52,6 +52,7 @@ void FGitSourceControlModule::StartupModule()
 	GitSourceControlProvider.RegisterWorker( "Copy", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitCopyWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "Resolve", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitResolveWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "MoveToChangelist", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitMoveToChangelistWorker> ) );
+	GitSourceControlProvider.RegisterWorker( "UpdateChangelistsStatus", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitUpdateStagingWorker> ) );
 
 	// load our settings
 	GitSourceControlSettings.LoadSettings();

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -855,4 +855,29 @@ bool FGitResolveWorker::UpdateStates() const
 	return GitSourceControlUtils::UpdateCachedStates(States);
 }
 
+FName FGitMoveToChangelistWorker::GetName() const
+{
+	return "MoveToChangelist";
+}
+
+bool FGitMoveToChangelistWorker::UpdateStates() const
+{
+	
+}
+
+bool FGitMoveToChangelistWorker::Execute(FGitSourceControlCommand& InCommand)
+{
+	check(InCommand.Operation->GetName() == GetName());
+
+	FGitSourceControlChangelist DestChangelist = InCommand.Changelist;
+	if(DestChangelist.GetName().Equals(TEXT("Staged")))
+	{
+		// git add
+	}
+	else if(DestChangelist.GetName().Equals(TEXT("Working")))
+	{
+		// git reset HEAD
+	}
+}
+
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -862,7 +862,7 @@ FName FGitMoveToChangelistWorker::GetName() const
 
 bool FGitMoveToChangelistWorker::UpdateStates() const
 {
-	return false;
+	return true;
 }
 
 bool FGitMoveToChangelistWorker::Execute(FGitSourceControlCommand& InCommand)
@@ -888,6 +888,21 @@ bool FGitMoveToChangelistWorker::Execute(FGitSourceControlCommand& InCommand)
 		GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, InCommand.Files, InCommand.ResultInfo.InfoMessages, DummyStates);
 	}
 	return bResult;
+}
+
+FName FGitUpdateStagingWorker::GetName() const
+{
+	return "UpdateChangelistsStatus";
+}
+
+bool FGitUpdateStagingWorker::Execute(FGitSourceControlCommand& InCommand)
+{
+	return GitSourceControlUtils::UpdateChangelistStateByCommand();
+}
+
+bool FGitUpdateStagingWorker::UpdateStates() const
+{
+	return true;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -862,7 +862,7 @@ FName FGitMoveToChangelistWorker::GetName() const
 
 bool FGitMoveToChangelistWorker::UpdateStates() const
 {
-	
+	return false;
 }
 
 bool FGitMoveToChangelistWorker::Execute(FGitSourceControlCommand& InCommand)
@@ -878,6 +878,7 @@ bool FGitMoveToChangelistWorker::Execute(FGitSourceControlCommand& InCommand)
 	{
 		// git reset HEAD
 	}
+	return false;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -545,8 +545,9 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 		}
 		if (AllExistingFiles.Num() > 0)
 		{
-			// reset any changes already added to the index
+			// reset and revert any changes already added to the index
 			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("reset"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), AllExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("checkout"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), AllExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 		}
 		if (OtherThanAddedExistingFiles.Num() > 0)
 		{

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -870,15 +870,24 @@ bool FGitMoveToChangelistWorker::Execute(FGitSourceControlCommand& InCommand)
 	check(InCommand.Operation->GetName() == GetName());
 
 	FGitSourceControlChangelist DestChangelist = InCommand.Changelist;
+	bool bResult = false;
 	if(DestChangelist.GetName().Equals(TEXT("Staged")))
 	{
-		// git add
+		bResult = GitSourceControlUtils::RunCommand(TEXT("add"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), InCommand.Files, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 	}
 	else if(DestChangelist.GetName().Equals(TEXT("Working")))
 	{
-		// git reset HEAD
+		TArray<FString> Parameter;
+		Parameter.Add(TEXT("--staged"));
+		bResult = GitSourceControlUtils::RunCommand(TEXT("restore"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, Parameter, InCommand.Files, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 	}
-	return false;
+	
+	if (bResult)
+	{
+		TMap<FString, FGitSourceControlState> DummyStates;
+		GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, InCommand.Files, InCommand.ResultInfo.InfoMessages, DummyStates);
+	}
+	return bResult;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.h
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.h
@@ -195,3 +195,16 @@ public:
 	/** Temporary states for results */
 	TMap<const FString, FGitState> States;
 };
+
+class FGitUpdateStagingWorker: public IGitSourceControlWorker
+{
+public:
+	virtual ~FGitUpdateStagingWorker() {}
+	// IGitSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(class FGitSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() const override;
+	
+	/** Temporary states for results */
+	TMap<const FString, FGitState> States;
+};

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.h
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.h
@@ -182,3 +182,16 @@ public:
 	/** Temporary states for results */
 	TMap<const FString, FGitState> States;
 };
+
+class FGitMoveToChangelistWorker : public IGitSourceControlWorker
+{
+public:
+	virtual ~FGitMoveToChangelistWorker() {}
+	// IGitSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(class FGitSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() const override;
+	
+	/** Temporary states for results */
+	TMap<const FString, FGitState> States;
+};

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -15,6 +15,7 @@
 #include "GitSourceControlUtils.h"
 #include "SGitSourceControlSettings.h"
 #include "GitSourceControlRunner.h"
+#include "GitSourceControlChangelistState.h"
 #include "Logging/MessageLog.h"
 #include "ScopedSourceControlProgress.h"
 #include "SourceControlHelpers.h"

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -424,6 +424,9 @@ ECommandResult::Type FGitSourceControlProvider::Execute( const FSourceControlOpe
 	Command->UpdateRepositoryRootIfSubmodule(AbsoluteFiles);
 	Command->OperationCompleteDelegate = InOperationCompleteDelegate;
 
+	TSharedPtr<FGitSourceControlChangelist, ESPMode::ThreadSafe> ChangelistPtr = StaticCastSharedPtr<FGitSourceControlChangelist>(InChangelist);
+	Command->Changelist = ChangelistPtr ? ChangelistPtr.ToSharedRef().Get() : FGitSourceControlChangelist();
+	
 	// fire off operation
 	if(InConcurrency == EConcurrency::Synchronous)
 	{

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -20,6 +20,7 @@
 #include "ScopedSourceControlProgress.h"
 #include "SourceControlHelpers.h"
 #include "SourceControlOperations.h"
+#include "AssetRegistry/AssetRegistryModule.h"
 #include "Async/Async.h"
 #include "GenericPlatform/GenericPlatformFile.h"
 #include "HAL/FileManager.h"
@@ -47,6 +48,9 @@ void FGitSourceControlProvider::Init(bool bForceConnection)
 	}
 
 	UPackage::PackageSavedWithContextEvent.AddStatic(&GitSourceControlUtils::UpdateFileStagingOnSaved);
+	
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+	AssetRegistryModule.Get().OnAssetRenamed().AddStatic(&GitSourceControlUtils::UpdateStateOnAssetRename);	
 
 	// bForceConnection: not used anymore
 }

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -709,14 +709,6 @@ TArray<FSourceControlChangelistRef> FGitSourceControlProvider::GetChangelists( E
 	{
 		return TArray<FSourceControlChangelistRef>();
 	}
-
-	if (InStateCacheUsage == EStateCacheUsage::ForceUpdate)
-	{
-		TSharedRef<class FUpdatePendingChangelistsStatus, ESPMode::ThreadSafe> UpdatePendingChangelistsOperation = ISourceControlOperation::Create<FUpdatePendingChangelistsStatus>();
-		UpdatePendingChangelistsOperation->SetUpdateAllChangelists(true);
-		
-		ISourceControlProvider::Execute(UpdatePendingChangelistsOperation, EConcurrency::Synchronous);
-	}
 	
 	TArray<FSourceControlChangelistRef> Changelists;
 	Algo::Transform(ChangelistsStateCache, Changelists, [](const auto& Pair) { return MakeShared<FGitSourceControlChangelist, ESPMode::ThreadSafe>(Pair.Key); });

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -46,6 +46,8 @@ void FGitSourceControlProvider::Init(bool bForceConnection)
 		CheckGitAvailability();
 	}
 
+	UPackage::PackageSavedWithContextEvent.AddStatic(&GitSourceControlUtils::UpdateFileStagingOnSaved);
+
 	// bForceConnection: not used anymore
 }
 

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "GitSourceControlChangelist.h"
 #include "ISourceControlProvider.h"
 #include "IGitSourceControlWorker.h"
 #include "GitSourceControlMenu.h"
@@ -273,6 +274,7 @@ private:
 
 	/** State cache */
 	TMap<FString, TSharedRef<class FGitSourceControlState, ESPMode::ThreadSafe> > StateCache;
+	TMap<FGitSourceControlChangelist, TSharedRef<class FGitSourceControlChangelistState, ESPMode::ThreadSafe> > ChangelistsStateCache;
 
 	/** The currently registered revision control operations */
 	TMap<FName, FGetGitSourceControlWorker> WorkersMap;

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.h
@@ -11,6 +11,7 @@
 #include "GitSourceControlMenu.h"
 #include "Runtime/Launch/Resources/Version.h"
 
+class FGitSourceControlChangelistState;
 class FGitSourceControlState;
 
 class FGitSourceControlCommand;
@@ -170,6 +171,9 @@ public:
 	/** Helper function used to update state cache */
 	TSharedRef<FGitSourceControlState, ESPMode::ThreadSafe> GetStateInternal(const FString& Filename);
 
+	/** Helper function used to update changelists state cache */
+	TSharedRef<FGitSourceControlChangelistState, ESPMode::ThreadSafe> GetStateInternal(const FGitSourceControlChangelist& InChangelist);
+	
 	/**
 	 * Register a worker with the provider.
 	 * This is used internally so the provider can maintain a map of all available operations.

--- a/Source/GitSourceControl/Private/GitSourceControlState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "GitSourceControlChangelist.h"
 #include "GitSourceControlRevision.h"
 #include "Runtime/Launch/Resources/Version.h"
 
@@ -202,6 +203,8 @@ public:
 
 	/** Status of the file */
 	FGitState State;
+
+	FGitSourceControlChangelist Changelist;
 
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1646,18 +1646,19 @@ static bool UpdateChangelistState(const TArray<FString>& Results)
 		if (!TChar<TCHAR>::IsWhitespace(Result[0]))
 		{
 			WorkingChangelist->Files.Remove(State);
+			State->Changelist = FGitSourceControlChangelist::StagedChangelist;
 			StagedChangelist->Files.AddUnique(State);
 		}
 		// Working check
 		if (!TChar<TCHAR>::IsWhitespace(Result[1]))
 		{
 			StagedChangelist->Files.Remove(State);
+			State->Changelist = FGitSourceControlChangelist::WorkingChangelist;
 			WorkingChangelist->Files.AddUnique(State);
 		}
 	}
 	return true;
 }
-	
 	
 // Run a batch of Git "status" command to update status of given files and/or directories.
 bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const bool InUsingLfsLocking, const TArray<FString>& InFiles,

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -34,6 +34,7 @@
 #include "PackageTools.h"
 #include "FileHelpers.h"
 #include "Misc/MessageDialog.h"
+#include "UObject/ObjectSaveContext.h"
 
 #include "Async/Async.h"
 #include "UObject/Linker.h"
@@ -1696,6 +1697,26 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 	CheckRemote(InPathToGitBinary, InRepositoryRoot, RepoFiles, OutErrorMessages, OutStates);
 
 	return bResult;
+}
+
+void UpdateFileStagingOnSaved(const FString& Filename, UPackage* Pkg, FObjectPostSaveContext ObjectSaveContext)
+{
+	FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
+   	FGitSourceControlProvider& Provider = GitSourceControl.GetProvider();
+   	if (!Provider.IsGitAvailable())
+   	{
+   		return ;
+   	}
+	TSharedRef<FGitSourceControlState, ESPMode::ThreadSafe> State = Provider.GetStateInternal(Filename);
+
+	if (State->Changelist.GetName().Equals(TEXT("Staged")))
+	{
+		TArray<FString> File;
+		File.Add(Filename);
+		TArray<FString> DummyResults;
+		TArray<FString> DummyMsgs;
+		const bool bResult = RunCommand(TEXT("add"), Provider.GetGitBinaryPath(), Provider.GetPathToRepositoryRoot(), FGitSourceControlModule::GetEmptyStringArray(), File, DummyResults, DummyMsgs);
+	}
 }
 
 // Run a Git `cat-file --filters` command to dump the binary content of a revision into a file.

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -239,6 +239,26 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
  */
 void UpdateFileStagingOnSaved(const FString& Filename, UPackage* Pkg, FObjectPostSaveContext ObjectSaveContext);
 	
+void UpdateFileStagingOnSavedInternal(const FString& Filename);
+	
+/**
+ * 
+ *
+ * @param	Filename			Saved filename
+ * @param	Pkg					Package (for adapting delegate)
+ * @param   ObjectSaveContext	Context for save (for adapting delegate)
+ */    
+void UpdateStateOnAssetRename(const FAssetData& InAssetData, const FString& InOldName);
+	
+/**
+ * 
+ *
+ * @param	Filename			Saved filename
+ * @param	Pkg					Package (for adapting delegate)
+ * @param   ObjectSaveContext	Context for save (for adapting delegate)
+ */
+bool UpdateChangelistStateByCommand();
+	
 /**
  * Run a Git "cat-file" command to dump the binary content of a revision into a file.
  *

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -230,7 +230,15 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
  */
 bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const bool InUsingLfsLocking, const TArray<FString>& InFiles,
 					 TArray<FString>& OutErrorMessages, TMap<FString, FGitSourceControlState>& OutStates);
-
+/**
+ * 
+ *
+ * @param	Filename			Saved filename
+ * @param	Pkg					Package (for adapting delegate)
+ * @param   ObjectSaveContext	Context for save (for adapting delegate)
+ */
+void UpdateFileStagingOnSaved(const FString& Filename, UPackage* Pkg, FObjectPostSaveContext ObjectSaveContext);
+	
 /**
  * Run a Git "cat-file" command to dump the binary content of a revision into a file.
  *

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -230,8 +230,9 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
  */
 bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const bool InUsingLfsLocking, const TArray<FString>& InFiles,
 					 TArray<FString>& OutErrorMessages, TMap<FString, FGitSourceControlState>& OutStates);
+	
 /**
- * 
+ * Keep Consistency of being file staged
  *
  * @param	Filename			Saved filename
  * @param	Pkg					Package (for adapting delegate)
@@ -239,7 +240,12 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
  */
 void UpdateFileStagingOnSaved(const FString& Filename, UPackage* Pkg, FObjectPostSaveContext ObjectSaveContext);
 	
-void UpdateFileStagingOnSavedInternal(const FString& Filename);
+/**
+ * Keep Consistency of being file staged with simple argument
+ *
+ * @param	Filename			Saved filename
+ */
+bool UpdateFileStagingOnSavedInternal(const FString& Filename);
 	
 /**
  * 


### PR DESCRIPTION
## Background
### Summary
The current implementation of UEGitPlugin has the following problem when dealing with files that manage OFPA.

1. In the OS-side file system, the OFPA file name is a hash value of the path on the editor side.
   This means that when staging a file using a Git client outside the editor, it's not intuitive that the correspondence between the file name and the actors on the level.

3. Actors managed by OFPA are not reflected in ContentBrowser, and cannot be "CheckIn" from the context menu.

### Detail
As to 1, when committing using a Git client outside of the editor, you have to choose from following:
- commit all OFPA files at once.
  - The significance of using OFPA is reduced by one.
  - The risk of conflicts increases when committing all the files at once.
- commit them after checking their correspondences one by one.
  - More work is required to check the correspondence, which can lead to mistakes and conflicts.

As mentioned above, the name of an OFPA file is a hash value. So it is not clear which actor is in conflict, which increases the annoying work.

As to 2, you cannot commit the OFPA within the editor in the first place.

## Implementation

Therefore, we have implemented a mechanism that allows staging OFPA and other assets by diverting the Changelist mechanism.
- I implemented it so that only WorkingChangelist and StagedChangelist can be used, and it reflects the result of the "git status" command.
  ![ChangelistExample](https://github.com/ProjectBorealis/UEGitPlugin/assets/29685796/195d0453-f0e3-40ca-b3c8-b2cc5c674cd8)

- Staging/Unstaging can now be done by dragging and dropping the ChangelistRow.
  - This is similar to Perforce and Plastic's Chnagelist.
  ![Staging-Unstaging](https://github.com/ProjectBorealis/UEGitPlugin/assets/29685796/3a4d0aea-bbc4-4b3c-9919-725c00da8a23)

- We can Revert File including OFPA.
  ![RevertDemo](https://github.com/ProjectBorealis/UEGitPlugin/assets/29685796/7962fa7f-f221-4d76-b39d-bb8224f0d693)

- Changelist reflect renaming. But if you want to reflect OFPA renaming, have to reopen Changelist.
  ![RenameOFPADemo](https://github.com/ProjectBorealis/UEGitPlugin/assets/29685796/af066989-6f47-49f1-8d10-d4c3d98b2569)


## Notes

However, the following notes apply.
- When Revert an actor or level from Changelist, it is necessary to unload the corresponding level before doing so.
  - This is caused by the fact that the appropriate flag is not passed to the function that calls the Revert command in OnRevert() of SourceControlChangelistRow.
  - This can be fixed with a small change in the engine, and we will send a pull request to the engine in the near future.
- When Recompile is performed from Changelist, the Engine's Content is registered in UncontrolledChangelist. In this case, a dialog box will appear every time the "git status" command is run behind the scenes.
  - In this situation, reverting the content in UncontrolledChangelist will possibly cause the engine to crash.
  - To repair it, try to launch the engine from the EpicGames launcher, it will crash again and "Launch" will change to "Repair".