### PR TITLE
fix compliation issue on UE version prior to 5.3

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.h
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.h
@@ -27,10 +27,12 @@ public:
 		return ChangelistName != InOther.ChangelistName;
 	}
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 	virtual bool IsDefault() const override
 	{
 		return ChangelistName == WorkingChangelist.ChangelistName;
 	}
+#endif
 
 	void SetInitialized()
 	{
@@ -58,10 +60,12 @@ public:
 		return ChangelistName;
 	}
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 	virtual FString GetIdentifier() const override
 	{
 		return ChangelistName;
 	}
+#endif
 
 public:
 	static FGitSourceControlChangelist WorkingChangelist;


### PR DESCRIPTION
Thank you for this great latest update on dev !

There's a compilation issue on GitSourceControlChangelist.h because of missing functions in the ISourceControlChangelist interface when building against 5.2, Most likely due to a change in 5.3.

Here's a fix.