### PR TITLE
Fix PathToRepositoryRoot when it's not the projectDir

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -104,6 +104,8 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 		bGitRepositoryFound = false;
 		return;
 	}
+	PathToRepositoryRoot = PathToGitRoot;
+
 	if (!GitSourceControlUtils::CheckGitAvailability(PathToGitBinary, &GitVersion))
 	{
 		UE_LOG(LogSourceControl, Error, TEXT("Failed to find valid Git executable."));


### PR DESCRIPTION
Proposal to fix bug #131, for repositories where the Unreal project is not at the root.
I hope this helps!