### PR TITLE
Use static names

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -41,6 +41,7 @@
 #include "UObject/Linker.h"
 
 static const FName GitSourceControlMenuTabName(TEXT("GitSourceControlMenu"));
+static const FName LevelEditorName(TEXT("LevelEditor"));
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"
 
@@ -49,7 +50,7 @@ TWeakPtr<SNotificationItem> FGitSourceControlMenu::OperationInProgressNotificati
 void FGitSourceControlMenu::Register()
 {
 #if ENGINE_MAJOR_VERSION >= 5
-	FToolMenuOwnerScoped SourceControlMenuOwner("GitSourceControlMenu");
+    FToolMenuOwnerScoped SourceControlMenuOwner( GitSourceControlMenuTabName );
 	if (UToolMenus* ToolMenus = UToolMenus::Get())
 	{
 		UToolMenu* SourceControlMenu = ToolMenus->ExtendMenu("StatusBar.ToolBar.SourceControl");
@@ -59,7 +60,7 @@ void FGitSourceControlMenu::Register()
 	}
 #else
 	// Register the extension with the level editor
-	FLevelEditorModule* LevelEditorModule = FModuleManager::GetModulePtr<FLevelEditorModule>(TEXT("LevelEditor"));
+    FLevelEditorModule * LevelEditorModule = FModuleManager::GetModulePtr< FLevelEditorModule >( LevelEditorName );
 	if (LevelEditorModule)
 	{
 		FLevelEditorModule::FLevelEditorMenuExtender ViewMenuExtender = FLevelEditorModule::FLevelEditorMenuExtender::CreateRaw(this, &FGitSourceControlMenu::OnExtendLevelEditorViewMenu);
@@ -79,7 +80,7 @@ void FGitSourceControlMenu::Unregister()
 	}
 #else
 	// Unregister the level editor extensions
-	FLevelEditorModule* LevelEditorModule = FModuleManager::GetModulePtr<FLevelEditorModule>("LevelEditor");
+    FLevelEditorModule * LevelEditorModule = FModuleManager::GetModulePtr< FLevelEditorModule >( LevelEditorName );
 	if (LevelEditorModule)
 	{
 		LevelEditorModule->GetAllLevelEditorToolbarSourceControlMenuExtenders().RemoveAll([=](const FLevelEditorModule::FLevelEditorMenuExtender& Extender) { return Extender.GetHandle() == ViewMenuExtenderHandle; });

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -30,6 +30,12 @@
 
 TArray<FString> FGitSourceControlModule::EmptyStringArray;
 
+namespace
+{
+    static const FName NAME_SourceControl( TEXT( "SourceControl" ) );
+    static const FName NAME_ContentBrowser( TEXT( "ContentBrowser" ) );
+}
+
 template<typename Type>
 static TSharedRef<IGitSourceControlWorker, ESPMode::ThreadSafe> CreateWorker()
 {
@@ -58,9 +64,9 @@ void FGitSourceControlModule::StartupModule()
 	GitSourceControlSettings.LoadSettings();
 
 	// Bind our revision control provider to the editor
-	IModularFeatures::Get().RegisterModularFeature( "SourceControl", &GitSourceControlProvider );
+    IModularFeatures::Get().RegisterModularFeature( NAME_SourceControl, &GitSourceControlProvider );
 
-	FContentBrowserModule& ContentBrowserModule = FModuleManager::Get().LoadModuleChecked<FContentBrowserModule>("ContentBrowser");
+	FContentBrowserModule & ContentBrowserModule = FModuleManager::Get().LoadModuleChecked< FContentBrowserModule >( NAME_ContentBrowser );
 
 #if ENGINE_MAJOR_VERSION >= 5
 	// Register ContentBrowserDelegate Handles for UE5 EA
@@ -86,11 +92,11 @@ void FGitSourceControlModule::ShutdownModule()
 	GitSourceControlProvider.Close();
 
 	// unbind provider from editor
-	IModularFeatures::Get().UnregisterModularFeature("SourceControl", &GitSourceControlProvider);
+    IModularFeatures::Get().UnregisterModularFeature( NAME_SourceControl, &GitSourceControlProvider );
 
 
 	// Unregister ContentBrowserDelegate Handles
-    FContentBrowserModule & ContentBrowserModule = FModuleManager::Get().LoadModuleChecked< FContentBrowserModule >( "ContentBrowser" );
+    FContentBrowserModule & ContentBrowserModule = FModuleManager::Get().LoadModuleChecked< FContentBrowserModule >( NAME_ContentBrowser );
 #if ENGINE_MAJOR_VERSION >= 5
 	ContentBrowserModule.GetOnFilterChanged().Remove( CbdHandle_OnFilterChanged );
 	ContentBrowserModule.GetOnSearchBoxChanged().Remove( CbdHandle_OnSearchBoxChanged );

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -96,7 +96,7 @@ void FGitSourceControlModule::ShutdownModule()
 
 
 	// Unregister ContentBrowserDelegate Handles
-    FContentBrowserModule & ContentBrowserModule = FModuleManager::Get().LoadModuleChecked< FContentBrowserModule >( NAME_ContentBrowser );
+    FContentBrowserModule & ContentBrowserModule = FModuleManager::Get().GetModuleChecked< FContentBrowserModule >( NAME_ContentBrowser );
 #if ENGINE_MAJOR_VERSION >= 5
 	ContentBrowserModule.GetOnFilterChanged().Remove( CbdHandle_OnFilterChanged );
 	ContentBrowserModule.GetOnSearchBoxChanged().Remove( CbdHandle_OnSearchBoxChanged );


### PR DESCRIPTION
We sometimes have deadlocks when running the engine in headless mode on Jenkins nodes when the editor closes.
This is because when the module unloads, it sometimes uses the module that handles FNames, which may be unloaded already.
I replaced a few names that were constructed dynamically by static ones