### PR TITLE
Changed `GetMissingVsExistingFiles` to force update the state from the Provider.

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -479,7 +479,7 @@ void GetMissingVsExistingFiles(const TArray<FString>& InFiles, TArray<FString>& 
 	const TArray<FString> Files = (InFiles.Num() > 0) ? (InFiles) : (Provider.GetFilesInCache());
 
 	TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> LocalStates;
-	Provider.GetState(Files, LocalStates, EStateCacheUsage::Use);
+	Provider.GetState(Files, LocalStates, EStateCacheUsage::ForceUpdate);
 	for (const auto& State : LocalStates)
 	{
 		if (FPaths::FileExists(State->GetFilename()))


### PR DESCRIPTION
Reverting an asset wasn't unlocking the files 100% of the time. Sometimes `GetMissingVsExistingFiles` would return empty and there would be nothing to revert or unlock.