### PR TITLE
Fix unnecessary popups when updated submodule or external package

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlCommand.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlCommand.cpp
@@ -28,7 +28,7 @@ FGitSourceControlCommand::FGitSourceControlCommand(const TSharedRef<class ISourc
 	PathToGitRoot = Provider.GetPathToGitRoot();
 }
 
-void FGitSourceControlCommand::UpdateRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths)
+void FGitSourceControlCommand::UpdateRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths)
 {
 	PathToRepositoryRoot = GitSourceControlUtils::ChangeRepositoryRootIfSubmodule(AbsoluteFilePaths, PathToRepositoryRoot);
 }

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -438,7 +438,7 @@ ECommandResult::Type FGitSourceControlProvider::Execute( const FSourceControlOpe
 		return ECommandResult::Failed;
 	}
 
-	const TArray<FString>& AbsoluteFiles = SourceControlHelpers::AbsoluteFilenames(InFiles);
+	TArray<FString> AbsoluteFiles = SourceControlHelpers::AbsoluteFilenames(InFiles);
 
 	// Query to see if we allow this operation
 	TSharedPtr<IGitSourceControlWorker, ESPMode::ThreadSafe> Worker = CreateWorker(InOperation->GetName());
@@ -458,8 +458,8 @@ ECommandResult::Type FGitSourceControlProvider::Execute( const FSourceControlOpe
 	}
 
 	FGitSourceControlCommand* Command = new FGitSourceControlCommand(InOperation, Worker.ToSharedRef());
-	Command->Files = AbsoluteFiles;
 	Command->UpdateRepositoryRootIfSubmodule(AbsoluteFiles);
+	Command->Files = AbsoluteFiles;
 	Command->OperationCompleteDelegate = InOperationCompleteDelegate;
 
 	TSharedPtr<FGitSourceControlChangelist, ESPMode::ThreadSafe> ChangelistPtr = StaticCastSharedPtr<FGitSourceControlChangelist>(InChangelist);

--- a/Source/GitSourceControl/Public/GitSourceControlCommand.h
+++ b/Source/GitSourceControl/Public/GitSourceControlCommand.h
@@ -40,7 +40,7 @@ public:
 	 *  Modify the repo root if all selected files are in a plugin subfolder, and the plugin subfolder is a git repo
 	 *  This supports the case where each plugin is a sub module
 	 */
-	void UpdateRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths);
+	void UpdateRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths);
 
 	/**
 	 * This is where the real thread work is done. All work that is done for

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -61,7 +61,7 @@ namespace GitSourceControlUtils
 		* @param AbsoluteFilePaths		The list of files in the SC operation
 		* @param PathToRepositoryRoot	The original path to the repository root (used by default)
 		*/
-	FString ChangeRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot);
+	FString ChangeRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot);
 
 	/**
 		*  Returns an updated repo root if all selected file is in a plugin subfolder, and the plugin subfolder is a git repo
@@ -70,7 +70,7 @@ namespace GitSourceControlUtils
 		* @param AbsoluteFilePath		The file in the SC operation
 		* @param PathToRepositoryRoot	The original path to the repository root (used by default)
 		*/
-	FString ChangeRepositoryRootIfSubmodule(const FString& AbsoluteFilePath, const FString& PathToRepositoryRoot);
+	FString ChangeRepositoryRootIfSubmodule(FString & AbsoluteFilePath, const FString& PathToRepositoryRoot);
 
 /**
  * Find the path to the Git binary, looking into a few places (standalone Git install, and other common tools embedding Git)


### PR DESCRIPTION
Fixed an issue where a popup like 'git command failed. please check your connection and try again' would appear when updating non-git packages such as engine content when the package file to be synced is a non-git package.