### PR TITLE
CheckLFSLockable correcly reports files with explicit not Lockable attribute

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2355,7 +2355,7 @@ bool CheckLFSLockable(const FString& InPathToGitBinary, const FString& InReposit
 	for (int i = 0; i < InFiles.Num(); i++)
 	{
 		const FString& Result = Results[i];
-		if (Result.EndsWith("set"))
+		if (Result.EndsWith("set") && !Result.EndsWith("unset"))
 		{
 			const FString FileExt = InFiles[i].RightChop(1); // Remove wildcard (*)
 			LockableTypes.Add(FileExt);


### PR DESCRIPTION
Fixes bug where any files marked in `.gitattributes` as `-lockable` would still return `false` from `CheckLFSLockable()`.
Files marked with `lockable` or with no explicit attribute would return the correct response (`true `and `false`, respectively)
See https://github.com/ProjectBorealis/UEGitPlugin/issues/180