### PR TITLE
Properly evaluate gitignore and skip ignored files

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlCommand.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlCommand.cpp
@@ -30,7 +30,7 @@ FGitSourceControlCommand::FGitSourceControlCommand(const TSharedRef<class ISourc
 
 void FGitSourceControlCommand::UpdateRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths)
 {
-	PathToRepositoryRoot = GitSourceControlUtils::ChangeRepositoryRootIfSubmodule(AbsoluteFilePaths, PathToRepositoryRoot);
+	PathToRepositoryRoot = GitSourceControlUtils::ChangeRepositoryRootIfSubmodule(AbsoluteFilePaths, PathToGitBinary, PathToRepositoryRoot);
 }
 
 bool FGitSourceControlCommand::DoWork()

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -458,7 +458,15 @@ ECommandResult::Type FGitSourceControlProvider::Execute( const FSourceControlOpe
 	}
 
 	FGitSourceControlCommand* Command = new FGitSourceControlCommand(InOperation, Worker.ToSharedRef());
+	const bool bCancelCommand = AbsoluteFiles.Num() > 0;
 	Command->UpdateRepositoryRootIfSubmodule(AbsoluteFiles);
+	if (bCancelCommand &&
+		AbsoluteFiles.Num() == 0)
+	{
+		delete Command;
+		return ECommandResult::Succeeded;
+	}
+
 	Command->Files = AbsoluteFiles;
 	Command->OperationCompleteDelegate = InOperationCompleteDelegate;
 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -124,7 +124,7 @@ void FGitLockedFilesCache::OnFileLockChanged(const FString& filePath, const FStr
 
 namespace GitSourceControlUtils
 {
-	FString ChangeRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot)
+	FString ChangeRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths, const FString& PathToGitBinary, const FString& PathToRepositoryRoot)
 	{
 		FString Ret = PathToRepositoryRoot;
 		// note this is not going to support operations where selected files are in different repositories
@@ -166,6 +166,7 @@ namespace GitSourceControlUtils
 				}
 			}
 		}
+
 		if (!PackageNotIncludedInGit.IsEmpty())
 		{
 			for (const FString& ToRemoveFile : PackageNotIncludedInGit)
@@ -174,13 +175,37 @@ namespace GitSourceControlUtils
 			}
 		}
 
+		if (AbsoluteFilePaths.Num() > 0)
+		{
+			PackageNotIncludedInGit = {};
+			PackageNotIncludedInGit.Reserve(AbsoluteFilePaths.Num());
+
+			TArray<FString> ErrorMessages;
+			RunCommand(
+				TEXT("check-ignore"),
+				PathToGitBinary,
+				PathToRepositoryRoot,
+				FGitSourceControlModule::GetEmptyStringArray(),
+				AbsoluteFilePaths,
+				PackageNotIncludedInGit,
+				ErrorMessages);
+
+			if (!PackageNotIncludedInGit.IsEmpty())
+			{
+				for (const FString& ToRemoveFile : PackageNotIncludedInGit)
+				{
+					AbsoluteFilePaths.Remove(ToRemoveFile);
+				}
+			}
+		}
+
 		return Ret;
 	}
 
-	FString ChangeRepositoryRootIfSubmodule(FString & AbsoluteFilePath, const FString& PathToRepositoryRoot)
+	FString ChangeRepositoryRootIfSubmodule(FString & AbsoluteFilePath, const FString& PathToGitBinary, const FString& PathToRepositoryRoot)
 	{
 		TArray<FString> AbsoluteFilePaths = { AbsoluteFilePath };
-		return ChangeRepositoryRootIfSubmodule(AbsoluteFilePaths, PathToRepositoryRoot);
+		return ChangeRepositoryRootIfSubmodule(AbsoluteFilePaths, PathToGitBinary, PathToRepositoryRoot);
 	}
 
 // Launch the Git command line process and extract its results & errors

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -59,18 +59,20 @@ namespace GitSourceControlUtils
 		*  This supports the case where each plugin is a sub module
 		*
 		* @param AbsoluteFilePaths		The list of files in the SC operation
+		* @param PathToGitBinary		The path to the Git binary
 		* @param PathToRepositoryRoot	The original path to the repository root (used by default)
 		*/
-	FString ChangeRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot);
+	FString ChangeRepositoryRootIfSubmodule(TArray<FString>& AbsoluteFilePaths, const FString& PathToGitBinary, const FString& PathToRepositoryRoot);
 
 	/**
 		*  Returns an updated repo root if all selected file is in a plugin subfolder, and the plugin subfolder is a git repo
 		*  This supports the case where each plugin is a sub module
 		*
 		* @param AbsoluteFilePath		The file in the SC operation
+		* @param PathToGitBinary		The path to the Git binary
 		* @param PathToRepositoryRoot	The original path to the repository root (used by default)
 		*/
-	FString ChangeRepositoryRootIfSubmodule(FString & AbsoluteFilePath, const FString& PathToRepositoryRoot);
+	FString ChangeRepositoryRootIfSubmodule(FString & AbsoluteFilePath, const FString& PathToGitBinary, const FString& PathToRepositoryRoot);
 
 /**
  * Find the path to the Git binary, looking into a few places (standalone Git install, and other common tools embedding Git)


### PR DESCRIPTION
This will evaluate `.gitignore` and skip files, which are ignored in the repo.
Main reason for this is to not throw error that git command failed, for files/directories which are ignored by the repo.