### PR TITLE
Add LFS locking checks for .uasset and .umap files in repository status

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -154,7 +154,7 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 				if (!GitSourceControlUtils::IsFileLFSLockable(".umap")
 					|| !GitSourceControlUtils::IsFileLFSLockable(".uasset"))
 				{
-					UE_LOG(LogSourceControl, Warning, TEXT("Git LFS Locking is disabled. Files .uasset or .umap are not lockable. Make sure your .gitattributes is setting lockable attributes for .uasset or .umap at the root of the git repository."));
+					UE_LOG(LogSourceControl, Error, TEXT("Git LFS Locking is disabled. Files .uasset or .umap are not lockable. Make sure your .gitattributes is setting lockable attributes for .uasset or .umap at the root of the git repository."));
 					bUsingGitLfsLocking = false;
 				}
 				else

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -149,6 +149,19 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 					UE_LOG(LogSourceControl, Error, TEXT("%s"), *ErrorMessage);
 				}
 			}
+			else
+			{
+				if (!GitSourceControlUtils::IsFileLFSLockable(".umap")
+					|| !GitSourceControlUtils::IsFileLFSLockable(".uasset"))
+				{
+					UE_LOG(LogSourceControl, Warning, TEXT("Git LFS Locking is disabled. Files .uasset or .umap are not lockable. Make sure your .gitattributes is setting lockable attributes for .uasset or .umap at the root of the git repository."));
+					bUsingGitLfsLocking = false;
+				}
+				else
+				{
+					UE_LOG(LogSourceControl, Log, TEXT("Git LFS Locking is enabled."));
+				}
+			}
 			const TArray<FString> ProjectDirs{FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
 											  FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
 											  FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -149,7 +149,7 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 					UE_LOG(LogSourceControl, Error, TEXT("%s"), *ErrorMessage);
 				}
 			}
-			else
+			else if (bUsingGitLfsLocking)
 			{
 				if (!GitSourceControlUtils::IsFileLFSLockable(".umap")
 					|| !GitSourceControlUtils::IsFileLFSLockable(".uasset"))

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2360,6 +2360,7 @@ bool CheckLFSLockable(const FString& InPathToGitBinary, const FString& InReposit
 {
 	TArray<FString> Results;
 	TArray<FString> Parameters;
+	LockableTypes.Empty(); // clear previous results
 	Parameters.Add(TEXT("lockable")); // follow file renames
 
 	const bool bResults = RunCommand(TEXT("check-attr"), InPathToGitBinary, InRepositoryRoot, Parameters, InFiles, Results, OutErrorMessages);


### PR DESCRIPTION
This check provides a helpful warning if git LFS lockable attributes are not detected by the plugin. 
The plugin only checks at the root of the git repo to decide if the repo can support LFS lock.
The check will fail when there is an issue with .gitattributes: if your project in not at the root of the repo or you're using the old content/** configuration from the default plugin.
If the check fails, it will disable git LFS locking, otherwise the plugin has a behavior, believing he can lock files but can't.