### PR TITLE
Fixed LogModuleManager: Warning: GetModule racing against IsReady: GitSourceControl spam

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -120,12 +120,14 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 		if (!IsInGameThread())
 		{
 			// Wait until the module interface is valid
-			IModuleInterface* GitModule;
 			do
 			{
-				GitModule = FModuleManager::Get().GetModule("GitSourceControl");
-				FPlatformProcess::Sleep(0.0f);
-			} while (!GitModule);
+				if (FModuleManager::Get().IsModuleLoaded("GitSourceControl"))
+				{
+					break;
+				}
+				FPlatformProcess::Sleep(0.01f);
+			} while (true);
 		}
 
 		// Get user name & email (of the repository, else from the global Git config)


### PR DESCRIPTION
Fix for issue #193. The problem was that GetModule issues a warning if it is called while the module is still loading.