### PR TITLE
Better support for reverting new and deleted files

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -474,11 +474,9 @@ void GroupFileCommandsForRevert(const TArray<FString>& InFiles, TArray<FString>&
 {
 	FGitSourceControlModule& GitSourceControl = FGitSourceControlModule::Get();
 	FGitSourceControlProvider& Provider = GitSourceControl.GetProvider();
-
-	const TArray<FString> Files = (InFiles.Num() > 0) ? (InFiles) : (Provider.GetFilesInCache());
-
+	
 	TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> LocalStates;
-	Provider.GetState(Files, LocalStates, EStateCacheUsage::Use);
+	Provider.GetState(InFiles, LocalStates, EStateCacheUsage::Use);
 	for (const auto& State : LocalStates)
 	{
 		if (State->IsAdded())

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -15,6 +15,7 @@
 #include "SourceControlHelpers.h"
 #include "Logging/MessageLog.h"
 #include "Misc/MessageDialog.h"
+#include "HAL/FileManager.h"
 #include "HAL/PlatformProcess.h"
 #include "GenericPlatform/GenericPlatformFile.h"
 #if ENGINE_MAJOR_VERSION >= 5
@@ -470,19 +471,38 @@ bool FGitDeleteWorker::UpdateStates() const
 }
 
 
-void GroupFileCommandsForRevert(const TArray<FString>& InFiles, TArray<FString>& FilesToRemove, TArray<FString>& FilesToCheckout)
+void GroupFileCommandsForRevert(const TArray<FString>& InFiles, TArray<FString>& FilesToRemove, TArray<FString>& FilesToCheckout, TArray<FString>& FilesToReset, TArray<FString>& FilesToDelete)
 {
 	FGitSourceControlModule& GitSourceControl = FGitSourceControlModule::Get();
 	FGitSourceControlProvider& Provider = GitSourceControl.GetProvider();
-	
+
 	TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> LocalStates;
 	Provider.GetState(InFiles, LocalStates, EStateCacheUsage::Use);
 	for (const auto& State : LocalStates)
 	{
 		if (State->IsAdded())
 		{
-			FilesToRemove.Add(State->GetFilename());
+			if (FPaths::FileExists(State->GetFilename()))
+			{
+				// Git rm won't delete the file because the engine still has it in use, and reset won't work on a file which doesn't exist on disk
+				// so we have to delete it ourselves, and then remove it from the index.
+				if (USourceControlPreferences::ShouldDeleteNewFilesOnRevert())
+				{
+					FilesToDelete.Add(State->GetFilename());
+					FilesToRemove.Add(State->GetFilename());
+				}
+				else
+				{
+					FilesToReset.Add(State->GetFilename());
+				}
+			}
+			else
+			{
+				// When you delete a file through content browser, UE will send a revert command to allow us to clean up the stage state.
+				FilesToRemove.Add(State->GetFilename());
+			}
 		}
+		// Checkout to head will reset the file back to what it is in your current commit, and reset the index.
 		else if (State->CanRevert())
 		{
 			FilesToCheckout.Add(State->GetFilename());
@@ -500,8 +520,7 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 	InCommand.bCommandSuccessful = true;
 
 	// Filter files by status
-	TArray<FString> AllFilesToRevert = InCommand.Files.Num() == 0 ? FGitSourceControlModule::Get().GetProvider().GetFilesInCache() : InCommand.Files;
-	const bool bRevertAll = InCommand.Files.Num() < 1;
+	const bool bRevertAll = InCommand.Files.Num() == 0;
 	if (bRevertAll)
 	{
 		TArray<FString> Params;
@@ -517,10 +536,23 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 	{
 		TArray<FString> FilesToRemove;
 		TArray<FString> FilesToCheckout;
-		GroupFileCommandsForRevert(InCommand.Files, FilesToRemove, FilesToCheckout);
+		TArray<FString> FilesToReset;
+		TArray<FString> FilesToDelete;
+		GroupFileCommandsForRevert(InCommand.Files, FilesToRemove, FilesToCheckout, FilesToReset, FilesToDelete);
 
-		// We've missed performing an operation on some files.
-		ensure(FilesToRemove.Num() + FilesToCheckout.Num() == InCommand.Files.Num());
+		// Verify we haven't missed performing an operation on any file passed on for revert
+		ensure(FilesToRemove.Num() + FilesToCheckout.Num() + FilesToReset.Num() == InCommand.Files.Num());
+
+		for (const FString& FileName : FilesToDelete)
+		{
+			bool RequireExists = true;
+			bool EvenReadOnly = true;
+			IFileManager::Get().Delete(*FileName, RequireExists, EvenReadOnly);
+		}
+		if (FilesToReset.Num() > 0)
+		{
+			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("reset"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), FilesToReset, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+		}
 		if (FilesToRemove.Num() > 0)
 		{
 			// "Added" files that have been deleted needs to be removed from revision control
@@ -536,12 +568,14 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 		}
 	}
 
+	// This is all the files we "asked" to revert, in the case of InCommand.Files everything *should* be changed
+	// in the case where we didn't pass in any files, we ran a revert on the repository root, so we should refresh everything
+	const TArray<FString>& RequestedReverts = bRevertAll ? FGitSourceControlModule::Get().GetProvider().GetFilesInCache() : InCommand.Files;
 	if (InCommand.bUsingGitLfsLocking)
 	{
 		// unlock files: execute the LFS command on relative filenames
-		// (unlock only locked files, that is, not Added files)
 		TArray<FString> LockedFiles;
-		GitSourceControlUtils::GetLockedFiles(AllFilesToRevert, LockedFiles);
+		GitSourceControlUtils::GetLockedFiles(RequestedReverts, LockedFiles);
 		if (LockedFiles.Num() > 0)
 		{
 			const TArray<FString>& RelativeFiles = GitSourceControlUtils::RelativeFilenames(LockedFiles, InCommand.PathToGitRoot);
@@ -559,7 +593,7 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 
 	// now update the status of our files
 	TMap<FString, FGitSourceControlState> UpdatedStates;
-	bool bSuccess = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, AllFilesToRevert, InCommand.ResultInfo.ErrorMessages, UpdatedStates);
+	bool bSuccess = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, RequestedReverts, InCommand.ResultInfo.ErrorMessages, UpdatedStates);
 	if (bSuccess)
 	{
 		GitSourceControlUtils::CollectNewStates(UpdatedStates, States);
@@ -640,8 +674,7 @@ bool FGitFetchWorker::Execute(FGitSourceControlCommand& InCommand)
 	if (Operation->bUpdateStatus)
 	{
 		// Now update the status of all our files
-		const TArray<FString> ProjectDirs {FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-										   FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};
+		const TArray<FString> ProjectDirs { FString(FPlatformProcess::BaseDir()) };
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking,
 																			  ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -674,7 +674,8 @@ bool FGitFetchWorker::Execute(FGitSourceControlCommand& InCommand)
 	if (Operation->bUpdateStatus)
 	{
 		// Now update the status of all our files
-		const TArray<FString> ProjectDirs { FString(FPlatformProcess::BaseDir()) };
+		const TArray<FString> ProjectDirs {FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
+										   FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking,
 																			  ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -470,8 +470,7 @@ bool FGitDeleteWorker::UpdateStates() const
 }
 
 
-// Get lists of Missing files (ie "deleted"), Modified files, and "other than Added" Existing files
-void GetMissingVsExistingFiles(const TArray<FString>& InFiles, TArray<FString>& OutMissingFiles, TArray<FString>& OutAllExistingFiles, TArray<FString>& OutOtherThanAddedExistingFiles)
+void GroupFileCommandsForRevert(const TArray<FString>& InFiles, TArray<FString>& FilesToRemove, TArray<FString>& FilesToCheckout)
 {
 	FGitSourceControlModule& GitSourceControl = FGitSourceControlModule::Get();
 	FGitSourceControlProvider& Provider = GitSourceControl.GetProvider();
@@ -482,29 +481,13 @@ void GetMissingVsExistingFiles(const TArray<FString>& InFiles, TArray<FString>& 
 	Provider.GetState(Files, LocalStates, EStateCacheUsage::Use);
 	for (const auto& State : LocalStates)
 	{
-		if (FPaths::FileExists(State->GetFilename()))
+		if (State->IsAdded())
 		{
-			if (State->IsAdded())
-			{
-				OutAllExistingFiles.Add(State->GetFilename());
-			}
-			else if (State->IsModified())
-			{
-				OutOtherThanAddedExistingFiles.Add(State->GetFilename());
-				OutAllExistingFiles.Add(State->GetFilename());
-			}
-			else if (State->CanRevert()) // for locked but unmodified files
-			{
-				OutOtherThanAddedExistingFiles.Add(State->GetFilename());
-			}
+			FilesToRemove.Add(State->GetFilename());
 		}
-		else
+		else if (State->CanRevert())
 		{
-			// If already queued for deletion, don't try to delete again
-			if (State->IsSourceControlled() && !State->IsDeleted())
-			{
-				OutMissingFiles.Add(State->GetFilename());
-			}
+			FilesToCheckout.Add(State->GetFilename());
 		}
 	}
 }
@@ -519,54 +502,39 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 	InCommand.bCommandSuccessful = true;
 
 	// Filter files by status
-	TArray<FString> MissingFiles;
-	TArray<FString> AllExistingFiles;
-	TArray<FString> OtherThanAddedExistingFiles;
-	GetMissingVsExistingFiles(InCommand.Files, MissingFiles, AllExistingFiles, OtherThanAddedExistingFiles);
-
+	TArray<FString> AllFilesToRevert = InCommand.Files.Num() == 0 ? FGitSourceControlModule::Get().GetProvider().GetFilesInCache() : InCommand.Files;
 	const bool bRevertAll = InCommand.Files.Num() < 1;
 	if (bRevertAll)
 	{
-		TArray<FString> Parms;
-		Parms.Add(TEXT("--hard"));
-		InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("reset"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, Parms, FGitSourceControlModule::GetEmptyStringArray(), InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+		TArray<FString> Params;
+		Params.Add(TEXT("--hard"));
+		InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("reset"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, Params, FGitSourceControlModule::GetEmptyStringArray(), InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 
-		Parms.Reset(2);
-		Parms.Add(TEXT("-f")); // force
-		Parms.Add(TEXT("-d")); // remove directories
-		InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("clean"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, Parms, FGitSourceControlModule::GetEmptyStringArray(), InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+		Params.Reset(2);
+		Params.Add(TEXT("-f")); // force
+		Params.Add(TEXT("-d")); // remove directories
+		InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("clean"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, Params, FGitSourceControlModule::GetEmptyStringArray(), InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 	}
 	else
 	{
-		if (MissingFiles.Num() > 0)
+		TArray<FString> FilesToRemove;
+		TArray<FString> FilesToCheckout;
+		GroupFileCommandsForRevert(InCommand.Files, FilesToRemove, FilesToCheckout);
+
+		// We've missed performing an operation on some files.
+		ensure(FilesToRemove.Num() + FilesToCheckout.Num() == InCommand.Files.Num());
+		if (FilesToRemove.Num() > 0)
 		{
 			// "Added" files that have been deleted needs to be removed from revision control
-			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("rm"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), MissingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("rm"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), FilesToRemove, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 		}
-		if (AllExistingFiles.Num() > 0)
+		if (FilesToCheckout.Num() > 0)
 		{
-			// reset and revert any changes already added to the index
-			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("reset"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), AllExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
-			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("checkout"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), AllExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
-		}
-		if (OtherThanAddedExistingFiles.Num() > 0)
-		{
-			// revert any changes in working copy (this would fails if the asset was in "Added" state, since after "reset" it is now "untracked")
-			// may need to try a few times due to file locks from prior operations
-			bool CheckoutSuccess = false;
-			int32 Attempts = 10;
-			while( Attempts-- > 0 )
-			{
-				CheckoutSuccess = GitSourceControlUtils::RunCommand(TEXT("checkout"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, FGitSourceControlModule::GetEmptyStringArray(), OtherThanAddedExistingFiles, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
-				if (CheckoutSuccess)
-				{
-					break;
-				}
-
-				FPlatformProcess::Sleep(0.1f);
-			}
-			
-			InCommand.bCommandSuccessful &= CheckoutSuccess;
+			// HEAD param allows us to re-pull files which have been deleted.
+			TArray<FString> Params;
+			Params.Add(TEXT("HEAD"));
+			// Checkout back to the last commit for any modified files.
+			InCommand.bCommandSuccessful &= GitSourceControlUtils::RunCommand(TEXT("checkout"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, Params, FilesToCheckout, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
 		}
 	}
 
@@ -575,7 +543,7 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 		// unlock files: execute the LFS command on relative filenames
 		// (unlock only locked files, that is, not Added files)
 		TArray<FString> LockedFiles;
-		GitSourceControlUtils::GetLockedFiles(OtherThanAddedExistingFiles, LockedFiles);
+		GitSourceControlUtils::GetLockedFiles(AllFilesToRevert, LockedFiles);
 		if (LockedFiles.Num() > 0)
 		{
 			const TArray<FString>& RelativeFiles = GitSourceControlUtils::RelativeFilenames(LockedFiles, InCommand.PathToGitRoot);
@@ -591,19 +559,9 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 		}
 	}
 
-	// If no files were specified (full revert), refresh all relevant files instead of the specified files (which is an empty list in full revert)
-	// This is required so that files that were "Marked for add" have their status updated after a full revert.
-	TArray<FString> FilesToUpdate = InCommand.Files;
-	if (InCommand.Files.Num() <= 0)
-	{
-		for (const auto& File : MissingFiles) FilesToUpdate.Add(File);
-		for (const auto& File : AllExistingFiles) FilesToUpdate.Add(File);
-		for (const auto& File : OtherThanAddedExistingFiles) FilesToUpdate.Add(File);
-	}
-
 	// now update the status of our files
 	TMap<FString, FGitSourceControlState> UpdatedStates;
-	bool bSuccess = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, FilesToUpdate, InCommand.ResultInfo.ErrorMessages, UpdatedStates);
+	bool bSuccess = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, AllFilesToRevert, InCommand.ResultInfo.ErrorMessages, UpdatedStates);
 	if (bSuccess)
 	{
 		GitSourceControlUtils::CollectNewStates(UpdatedStates, States);


### PR DESCRIPTION
Currently if you run a revert on a deleted file through the source control submit window, you don't actually get the file back because of this piece of code:
`			// If already queued for deletion, don't try to delete again
			if (State->IsSourceControlled() && !State->IsDeleted())
			{
				OutMissingFiles.Add(State->GetFilename());
			}`
			
But the only place this function is used, is to *revert* files, so the revert action does nothing - with this change, the revert action will bring the file back to its state at HEAD - I had a bit of a look at the history of this, and it's quite unclear why it was needed, it was added quite a while back, I'd guess the engine used to handle deleting or reverting differently

In addition to this, the behavior of reverting an added file was just to unmark it for add - which is understandable that some folks would want that, but that's not the behavior we want at our studio, so I've made Revert on an added file also remove the file on disk **IF** you have USourceControlPreferences::ShouldDeleteNewFilesOnRevert() enabled
This is a property that already exists in the engine, and is used by the perforce integration to allow you to switch between the 2 behaviors listed here

There's also a general clean up, the code was a bit difficult to reason about, so I've refactored GetMissingVsExistingFiles into GroupFileCommandsForRevert which gives you lists of files sorted into buckets that we run different commands on so it's hopefully a bit simpler to follow