### PR TITLE
Support for Installed Engine Build

### DIFF
--- a/Source/GitSourceControl/GitSourceControl.Build.cs
+++ b/Source/GitSourceControl/GitSourceControl.Build.cs
@@ -29,5 +29,19 @@ public class GitSourceControl : ModuleRules
 		{
 			PrivateDependencyModuleNames.Add("ToolMenus");
 		}
+
+		if (Target.Platform == UnrealTargetPlatform.Win64)
+		{
+			RuntimeDependencies.Add("$(PluginDir)/git-lfs.exe");
+		}
+		else if (Target.Platform == UnrealTargetPlatform.Mac)
+		{
+			RuntimeDependencies.Add("$(PluginDir)/git-lfs-mac-amd64");
+			RuntimeDependencies.Add("$(PluginDir)/git-lfs-mac-arm64");			
+		}
+		else if (Target.Platform == UnrealTargetPlatform.Linux)
+		{
+			RuntimeDependencies.Add("$(PluginDir)/git-lfs");
+		}
 	}
 }


### PR DESCRIPTION
When you make an installed Engine Build the build pipeline will strip out any executables and libraries unless you specify that they're needed for the editor runtime - so that's all I've done here, just so the plugin can function in our installed engine build