### PR TITLE
Fix compile errors for Unreal Engine 4

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelist.cpp
@@ -1,4 +1,6 @@
-﻿#include "GitSourceControlChangelist.h"
+#if ENGINE_MAJOR_VERSION == 5
+#include "GitSourceControlChangelist.h"
 
 FGitSourceControlChangelist FGitSourceControlChangelist::WorkingChangelist(TEXT("Working"), true);
 FGitSourceControlChangelist FGitSourceControlChangelist::StagedChangelist(TEXT("Staged"), true);
+#endif

--- a/Source/GitSourceControl/Private/GitSourceControlChangelistState.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelistState.cpp
@@ -1,4 +1,5 @@
-﻿#include "GitSourceControlChangelistState.h"
+#if ENGINE_MAJOR_VERSION == 5
+#include "GitSourceControlChangelistState.h"
 
 #define LOCTEXT_NAMESPACE "GitSourceControl.ChangelistState"
 
@@ -72,3 +73,4 @@ FSourceControlChangelistRef FGitSourceControlChangelistState::GetChangelist() co
 }
 
 #undef LOCTEXT_NAMESPACE
+#endif

--- a/Source/GitSourceControl/Private/GitSourceControlChangelistState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlChangelistState.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+#pragma once
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5
 #include "GitSourceControlChangelist.h"
 #include "ISourceControlChangelistState.h"
 #include "ISourceControlState.h"
@@ -82,3 +84,4 @@ public:
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;
 };
+#endif

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -26,6 +26,7 @@
 #include "Framework/MultiBox/MultiBoxExtender.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Misc/ConfigCacheIni.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"
 
@@ -58,8 +59,10 @@ void FGitSourceControlModule::StartupModule()
 	GitSourceControlProvider.RegisterWorker( "CheckIn", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitCheckInWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "Copy", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitCopyWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "Resolve", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitResolveWorker> ) );
+#if ENGINE_MAJOR_VERSION == 5
 	GitSourceControlProvider.RegisterWorker( "MoveToChangelist", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitMoveToChangelistWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "UpdateChangelistsStatus", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitUpdateStagingWorker> ) );
+#endif
 
 	// load our settings
 	GitSourceControlSettings.LoadSettings();

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -856,6 +856,7 @@ bool FGitResolveWorker::UpdateStates() const
 	return GitSourceControlUtils::UpdateCachedStates(States);
 }
 
+#if ENGINE_MAJOR_VERSION == 5
 FName FGitMoveToChangelistWorker::GetName() const
 {
 	return "MoveToChangelist";
@@ -905,5 +906,6 @@ bool FGitUpdateStagingWorker::UpdateStates() const
 {
 	return true;
 }
+#endif
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.h
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.h
@@ -183,6 +183,7 @@ public:
 	TMap<const FString, FGitState> States;
 };
 
+#if ENGINE_MAJOR_VERSION == 5
 class FGitMoveToChangelistWorker : public IGitSourceControlWorker
 {
 public:
@@ -208,3 +209,4 @@ public:
 	/** Temporary states for results */
 	TMap<const FString, FGitState> States;
 };
+#endif

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -28,7 +28,12 @@
 #include "Misc/App.h"
 #include "Misc/EngineVersion.h"
 #include "Misc/MessageDialog.h"
+
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5
 #include "UObject/ObjectSaveContext.h"
+#endif
+
 #include "UObject/Package.h"
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"
@@ -49,7 +54,9 @@ void FGitSourceControlProvider::Init(bool bForceConnection)
 		CheckGitAvailability();
 	}
 
+#if ENGINE_MAJOR_VERSION == 5
 	UPackage::PackageSavedWithContextEvent.AddStatic(&GitSourceControlUtils::UpdateFileStagingOnSaved);
+#endif
 	
 	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
 	AssetRegistryModule.Get().OnAssetRenamed().AddStatic(&GitSourceControlUtils::UpdateStateOnAssetRename);	
@@ -278,6 +285,7 @@ TSharedRef<FGitSourceControlState, ESPMode::ThreadSafe> FGitSourceControlProvide
 	}
 }
 
+#if ENGINE_MAJOR_VERSION == 5
 TSharedRef<FGitSourceControlChangelistState, ESPMode::ThreadSafe> FGitSourceControlProvider::GetStateInternal(const FGitSourceControlChangelist& InChangelist)
 {
 	TSharedRef<FGitSourceControlChangelistState, ESPMode::ThreadSafe>* State = ChangelistsStateCache.Find(InChangelist);
@@ -294,6 +302,7 @@ TSharedRef<FGitSourceControlChangelistState, ESPMode::ThreadSafe> FGitSourceCont
 		return NewState;
 	}
 }
+#endif
 
 FText FGitSourceControlProvider::GetStatusText() const
 {
@@ -477,8 +486,10 @@ ECommandResult::Type FGitSourceControlProvider::Execute( const FSourceControlOpe
 	Command->Files = AbsoluteFiles;
 	Command->OperationCompleteDelegate = InOperationCompleteDelegate;
 
+#if ENGINE_MAJOR_VERSION == 5
 	TSharedPtr<FGitSourceControlChangelist, ESPMode::ThreadSafe> ChangelistPtr = StaticCastSharedPtr<FGitSourceControlChangelist>(InChangelist);
 	Command->Changelist = ChangelistPtr ? ChangelistPtr.ToSharedRef().Get() : FGitSourceControlChangelist();
+#endif
 	
 	// fire off operation
 	if(InConcurrency == EConcurrency::Synchronous)

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -34,7 +34,11 @@
 #include "PackageTools.h"
 #include "FileHelpers.h"
 #include "Misc/MessageDialog.h"
+
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5 
 #include "UObject/ObjectSaveContext.h"
+#endif
 
 #include "Async/Async.h"
 #include "UObject/Linker.h"
@@ -1631,6 +1635,7 @@ FString GetFullPathFromGitStatus(const FString& Result, const FString& InReposit
 	return File;
 }
 
+#if ENGINE_MAJOR_VERSION == 5
 bool UpdateChangelistStateByCommand()
 {
 	// TODO: This is a temporary solution.
@@ -1684,6 +1689,7 @@ bool UpdateChangelistStateByCommand()
 	}
 	return true;
 }
+#endif
 	
 // Run a batch of Git "status" command to update status of given files and/or directories.
 bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const bool InUsingLfsLocking, const TArray<FString>& InFiles,
@@ -1715,14 +1721,17 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 	{
 		ParseStatusResults(InPathToGitBinary, InRepositoryRoot, InUsingLfsLocking, RepoFiles, ResultsMap, OutStates);
 	}
-	
+
+#if ENGINE_MAJOR_VERSION == 5
 	UpdateChangelistStateByCommand();
+#endif
 
 	CheckRemote(InPathToGitBinary, InRepositoryRoot, RepoFiles, OutErrorMessages, OutStates);
 
 	return bResult;
 }
 
+#if ENGINE_MAJOR_VERSION == 5
 void UpdateFileStagingOnSaved(const FString& Filename, UPackage* Pkg, FObjectPostSaveContext ObjectSaveContext)
 {
 	UpdateFileStagingOnSavedInternal(Filename);
@@ -1750,6 +1759,7 @@ bool UpdateFileStagingOnSavedInternal(const FString& Filename)
 	
 	return bResult;
 }
+#endif
 	
 void UpdateStateOnAssetRename(const FAssetData& InAssetData, const FString& InOldName)
 {

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -170,7 +170,11 @@ namespace GitSourceControlUtils
 				}
 			}
 		}
+#if ENGINE_MAJOR_VERSION >= 5
 		if (!PackageNotIncludedInGit.IsEmpty())
+#else
+		if (PackageNotIncludedInGit.Num() > 0)
+#endif
 		{
 			for (const FString& ToRemoveFile : PackageNotIncludedInGit)
 			{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1770,8 +1770,12 @@ void UpdateStateOnAssetRename(const FAssetData& InAssetData, const FString& InOl
 		return ;
 	}
 	TSharedRef<FGitSourceControlState, ESPMode::ThreadSafe> State = Provider.GetStateInternal(InOldName);	
-	
+
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 	State->LocalFilename = InAssetData.GetObjectPathString();
+#else
+	State->LocalFilename = InAssetData.ObjectPath.ToString();
+#endif
 }
 
 // Run a Git `cat-file --filters` command to dump the binary content of a revision into a file.

--- a/Source/GitSourceControl/Public/GitSourceControlChangelist.h
+++ b/Source/GitSourceControl/Public/GitSourceControlChangelist.h
@@ -1,6 +1,8 @@
-﻿#pragma once
-#include "ISourceControlChangelist.h"
+#pragma once
 #include "Runtime/Launch/Resources/Version.h"
+
+#if ENGINE_MAJOR_VERSION == 5
+#include "ISourceControlChangelist.h"
 
 class FGitSourceControlChangelist : public ISourceControlChangelist
 {
@@ -78,3 +80,4 @@ private:
 };
 
 typedef TSharedRef<class FGitSourceControlChangelist, ESPMode::ThreadSafe> FGitSourceControlChangelistRef;
+#endif

--- a/Source/GitSourceControl/Public/GitSourceControlCommand.h
+++ b/Source/GitSourceControl/Public/GitSourceControlCommand.h
@@ -8,6 +8,7 @@
 #include "GitSourceControlChangelist.h"
 #include "ISourceControlProvider.h"
 #include "Misc/IQueuedWork.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 /** Accumulated error and info messages for a revision control operation.  */
 struct FGitSourceControlResultInfo
@@ -117,8 +118,10 @@ public:
 	/** Files to perform this operation on */
 	TArray<FString> Files;
 
-	/** Changelist to perform this operation on */
-	FGitSourceControlChangelist Changelist;
+#if ENGINE_MAJOR_VERSION == 5
+    /** Changelist to perform this operation on */
+    FGitSourceControlChangelist Changelist;
+#endif
 
 	/** Potential error, warning and info message storage */
 	FGitSourceControlResultInfo ResultInfo;

--- a/Source/GitSourceControl/Public/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Public/GitSourceControlProvider.h
@@ -171,8 +171,10 @@ public:
 	/** Helper function used to update state cache */
 	TSharedRef<FGitSourceControlState, ESPMode::ThreadSafe> GetStateInternal(const FString& Filename);
 
+#if ENGINE_MAJOR_VERSION == 5	
 	/** Helper function used to update changelists state cache */
 	TSharedRef<FGitSourceControlChangelistState, ESPMode::ThreadSafe> GetStateInternal(const FGitSourceControlChangelist& InChangelist);
+#endif
 	
 	/**
 	 * Register a worker with the provider.
@@ -278,7 +280,9 @@ private:
 
 	/** State cache */
 	TMap<FString, TSharedRef<class FGitSourceControlState, ESPMode::ThreadSafe> > StateCache;
+#if ENGINE_MAJOR_VERSION == 5
 	TMap<FGitSourceControlChangelist, TSharedRef<class FGitSourceControlChangelistState, ESPMode::ThreadSafe> > ChangelistsStateCache;
+#endif
 
 	/** The currently registered revision control operations */
 	TMap<FName, FGetGitSourceControlWorker> WorkersMap;

--- a/Source/GitSourceControl/Public/GitSourceControlState.h
+++ b/Source/GitSourceControl/Public/GitSourceControlState.h
@@ -205,7 +205,9 @@ public:
 	/** Status of the file */
 	FGitState State;
 
+#if ENGINE_MAJOR_VERSION == 5
 	FGitSourceControlChangelist Changelist;
+#endif
 
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -7,7 +7,10 @@
 
 #include "GitSourceControlRevision.h"
 #include "GitSourceControlState.h"
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5
 #include "UObject/ObjectSaveContext.h"
+#endif
 
 class FGitSourceControlState;
 
@@ -246,7 +249,8 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
  */
 bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const bool InUsingLfsLocking, const TArray<FString>& InFiles,
 					 TArray<FString>& OutErrorMessages, TMap<FString, FGitSourceControlState>& OutStates);
-	
+
+#if ENGINE_MAJOR_VERSION == 5
 /**
  * Keep Consistency of being file staged
  *
@@ -255,7 +259,8 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
  * @param   ObjectSaveContext	Context for save (for adapting delegate)
  */
 void UpdateFileStagingOnSaved(const FString& Filename, UPackage* Pkg, FObjectPostSaveContext ObjectSaveContext);
-	
+#endif
+
 /**
  * Keep Consistency of being file staged with simple argument
  *
@@ -271,7 +276,8 @@ bool UpdateFileStagingOnSavedInternal(const FString& Filename);
  * @param   ObjectSaveContext	Context for save (for adapting delegate)
  */    
 void UpdateStateOnAssetRename(const FAssetData& InAssetData, const FString& InOldName);
-	
+
+#if ENGINE_MAJOR_VERSION == 5
 /**
  * 
  *
@@ -280,6 +286,7 @@ void UpdateStateOnAssetRename(const FAssetData& InAssetData, const FString& InOl
  * @param   ObjectSaveContext	Context for save (for adapting delegate)
  */
 bool UpdateChangelistStateByCommand();
+#endif
 	
 /**
  * Run a Git "cat-file" command to dump the binary content of a revision into a file.


### PR DESCRIPTION
Fix #194
- There is no `ISourceControlChangelist` in UE 4.27, so it disables all changes related to changelists for `ENGINE_MAJOR_VERSION` < 5. Starting from commit [af6ce90](https://github.com/ProjectBorealis/UEGitPlugin/commit/af6ce90fe5b51c240ec78d49733ba79d70b00ce9) where support for changelists first appeared.
- There is no `UObject/ObjectSaveContext.h` in UE 4.27, so it disables feature `UpdateFileStagingOnSaved` from commit [d00586d](https://github.com/ProjectBorealis/UEGitPlugin/commit/d00586db4178569f62ef8a2528f7995158ba6e3d) for `ENGINE_MAJOR_VERSION` < 5.
- Replacing `FAssetData::GetObjectPathString()` since it is UE 5.1+