### PR TITLE
bugfix: changes on status branches are not detected

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1490,9 +1490,9 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 			// which means editor plugins are enabled and running, but they don't run UnrealEdEngine, so the status branches are not initialized.
 			if (StatusBranches.Num() > 0)
 			{
-				// Check if the files state in the branch in which is changed is actually different from status branch
+				// Check if the files state in the branch in which is changed is actually different from compared branch
 				// This opens files for edit if they were modified in another branch but have since been reverted back to state in status.
-				TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("%s..%s"), *StatusBranches[0], *Branch), TEXT(""), TEXT("--") };
+				TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("...%s"), *Branch), TEXT(""), TEXT("--") };
 				const bool bResultDiff = RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToDiff, DiffResults, ErrorMessages);
 				// Get the intersection of the 2 containers
 				Intersection = DiffResults.FilterByPredicate([&LogResults](const FString& ChangedFile) { return LogResults.Contains(ChangedFile); });


### PR DESCRIPTION
I never contributed to this repo, but I used it in few projects and recently found serious regression.
With latest version of the repo changes from status branches are not detected. I use very typical git workflow in my project - feature branches and master branch which is in our case the only registered status branch to which everything is merged.

Repro is straightforward:
1. Create new branch X from status branch (in our case master)
2. Merge pull request with changes in some file Y.uasset
Now file Y is outdated on branch X, working on it can result in later conflicts.
Expectation: File Y is marked on branch X as `Modified on branch origin/master` and can't be checked out.

That was not the case now, in the past I used older version of this repo and I remembered it worked correctly in such case, so I started debugging and discovered that regression was introduced [here](https://github.com/ProjectBorealis/UEGitPlugin/pull/197). 

The issue was that with previous git diff command we compared changes between main status branch and current target, but we already did it inside the loop iterating over all status branches so we did some nonsense comparisons eg. between the the same branch. In this context it make sense for me that we should always compare against current revision instead. 
That fixes case explained above and it works as expected for me, but would be great if author of this change @Darcy3000s could reflect on that, whether it was indeed a mistake, or was done on purpose which made sense in some different workflow.
Also pinging @mastercoms 
