### PR TITLE
Fix UE 5.5 Build

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -101,8 +101,11 @@ bool FGitSourceControlMenu::CanCommit() const
 {
 	// The 'Submit Content' operation could lead to a world reload (in UEFN) that takes the user out of their selected editor mode.
 	// Piggy back on the 'CanAutoSave' functionality to determine if now is a good time to trigger a 'Submit Content' SCC operation.
-
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
 	return GLevelEditorModeTools().CanAutoSave() && FSourceControlWindows::CanChoosePackagesToCheckIn();
+#else
+	return true;
+#endif
 }
 
 /// Prompt to save or discard all packages


### PR DESCRIPTION
Building on UE5.5 and probably earlier broken by the UE 5.6 workaround as it tries to call GLevelEditorModeTools().CanAutoSave() without the appropriate header.

This adds the same #if protection used to include the header around the call to CanAutoSave so it builds again.