### PR TITLE
Flush config so separate processes read settings

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -163,7 +163,7 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 				if (!GitSourceControlUtils::IsFileLFSLockable(".umap")
 					|| !GitSourceControlUtils::IsFileLFSLockable(".uasset"))
 				{
-					UE_LOG(LogSourceControl, Error, TEXT("Git LFS Locking is disabled. Files .uasset or .umap are not lockable. Make sure your .gitattributes is setting lockable attributes for .uasset or .umap at the root of the git repository."));
+					UE_LOG(LogSourceControl, Warning, TEXT("Git LFS Locking is disabled. Files .uasset or .umap are not lockable. Make sure your .gitattributes is setting lockable attributes for .uasset or .umap at the root of the git repository."));
 					bUsingGitLfsLocking = false;
 				}
 				else

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -163,7 +163,7 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 				if (!GitSourceControlUtils::IsFileLFSLockable(".umap")
 					|| !GitSourceControlUtils::IsFileLFSLockable(".uasset"))
 				{
-					UE_LOG(LogSourceControl, Warning, TEXT("Git LFS Locking is disabled. Files .uasset or .umap are not lockable. Make sure your .gitattributes is setting lockable attributes for .uasset or .umap at the root of the git repository."));
+					UE_LOG(LogSourceControl, Error, TEXT("Git LFS Locking is disabled. Files .uasset or .umap are not lockable. Make sure your .gitattributes is setting lockable attributes for .uasset or .umap at the root of the git repository."));
 					bUsingGitLfsLocking = false;
 				}
 				else

--- a/Source/GitSourceControl/Private/GitSourceControlSettings.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlSettings.cpp
@@ -83,4 +83,5 @@ void FGitSourceControlSettings::SaveSettings() const
 	GConfig->SetString(*GitSettingsConstants::SettingsSection, TEXT("BinaryPath"), *BinaryPath, IniFile);
 	GConfig->SetBool(*GitSettingsConstants::SettingsSection, TEXT("UsingGitLfsLocking"), bUsingGitLfsLocking, IniFile);
 	GConfig->SetString(*GitSettingsConstants::SettingsSection, TEXT("LfsUserName"), *LfsUserName, IniFile);
+	GConfig->Flush(false, IniFile);
 }


### PR DESCRIPTION
It makes more sense, in my opinion, to have this be a warning rather than an error. As an error, it prevents projects from packaging despite being a seemingly relatively minor issue. @sanxfxteam, since you wrote this snippet (and originally had it as a warning), I'm wondering if you might have any input as to why this might be better as an error log?