### PR TITLE
apple silicon brew stores git in different place

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -408,10 +408,17 @@ FString FindGitBinaryPath()
 	FString GitBinaryPath = TEXT("/usr/local/git/bin/git");
 	bool bFound = CheckGitAvailability(GitBinaryPath);
 
-	// 2) Else, look for the version of git provided by Homebrew
+		// 2) Else, look for the version of git provided by Homebrew
 	if (!bFound)
 	{
 		GitBinaryPath = TEXT("/usr/local/bin/git");
+		bFound = CheckGitAvailability(GitBinaryPath);
+	}
+
+	// 2.1) else apple silicon brew stores git in different place
+	if (!bFound)
+	{
+		GitBinaryPath = TEXT("/opt/homebrew/bin/git");
 		bFound = CheckGitAvailability(GitBinaryPath);
 	}
 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -408,7 +408,7 @@ FString FindGitBinaryPath()
 	FString GitBinaryPath = TEXT("/usr/local/git/bin/git");
 	bool bFound = CheckGitAvailability(GitBinaryPath);
 
-		// 2) Else, look for the version of git provided by Homebrew
+	// 2) Else, look for the version of git provided by Homebrew
 	if (!bFound)
 	{
 		GitBinaryPath = TEXT("/usr/local/bin/git");


### PR DESCRIPTION
title is kinda self explanatory, however the issue I initially encountered that on Mac arm that git-lfs sometimes is missing when using /usr/bin/git. 

```
LogSourceControl: Error: git-lfs filter-process: git-lfs: command not found
LogSourceControl: Error: fatal: the remote end hung up unexpectedly
```

probably related to #142 

I didnt find a root of the cause yet, but when I tried to use git from homebrew where apple silicon is used, I noticed that there is an old path for git from brew. 

adding another path to brew's git on apple silicon fixed the issue for me