### PR TITLE
Add Plugins to list of core source controlled paths to refresh

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -305,9 +305,11 @@ void FGitSourceControlMenu::RevertClicked()
 	}
 
 	// make sure we update the SCC status of all packages (this could take a long time, so we will run it as a background task)
-	const TArray<FString> Filenames {
+	const TArray<FString> Filenames
+	{
 		FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
 		FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
+		FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
 		FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
 	};
 

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -305,7 +305,7 @@ void FGitSourceControlMenu::RevertClicked()
 	}
 
 	// make sure we update the SCC status of all packages (this could take a long time, so we will run it as a background task)
-	const TArray<FString> Filenames = GitSourceControlUtils::GetImportantGitPaths();
+	const TArray<FString> Filenames = GitSourceControlUtils::GetSourceControlledAssetPaths();
 
 	ISourceControlProvider& SourceControlProvider = ISourceControlModule::Get().GetProvider();
 	FSourceControlOperationRef Operation = ISourceControlOperation::Create<FUpdateStatus>();

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -305,13 +305,7 @@ void FGitSourceControlMenu::RevertClicked()
 	}
 
 	// make sure we update the SCC status of all packages (this could take a long time, so we will run it as a background task)
-	const TArray<FString> Filenames
-	{
-		FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
-		FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-		FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
-		FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
-	};
+	const TArray<FString> Filenames = GitSourceControlUtils::GetImportantGitPaths();
 
 	ISourceControlProvider& SourceControlProvider = ISourceControlModule::Get().GetProvider();
 	FSourceControlOperationRef Operation = ISourceControlOperation::Create<FUpdateStatus>();

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -684,13 +684,7 @@ bool FGitFetchWorker::Execute(FGitSourceControlCommand& InCommand)
 	if (Operation->bUpdateStatus)
 	{
 		// Now update the status of all our files
-		const TArray<FString> ProjectDirs
-		{
-			FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
-			FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-			FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
-			FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
-		};
+		const TArray<FString> ProjectDirs = GitSourceControlUtils::GetImportantGitPaths();
 
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking,
@@ -753,13 +747,7 @@ bool FGitUpdateStatusWorker::Execute(FGitSourceControlCommand& InCommand)
 	else
 	{
 		// no path provided: only update the status of assets in Content/ directory and also Config files
-		const TArray<FString> ProjectDirs
-		{
-			FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
-			FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-			FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
-			FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
-		};
+		const TArray<FString> ProjectDirs = GitSourceControlUtils::GetImportantGitPaths();
 		
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -684,8 +684,14 @@ bool FGitFetchWorker::Execute(FGitSourceControlCommand& InCommand)
 	if (Operation->bUpdateStatus)
 	{
 		// Now update the status of all our files
-		const TArray<FString> ProjectDirs {FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-										   FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};
+		const TArray<FString> ProjectDirs
+		{
+			FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
+			FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
+			FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
+			FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
+		};
+
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking,
 																			  ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -684,7 +684,7 @@ bool FGitFetchWorker::Execute(FGitSourceControlCommand& InCommand)
 	if (Operation->bUpdateStatus)
 	{
 		// Now update the status of all our files
-		const TArray<FString> ProjectDirs = GitSourceControlUtils::GetImportantGitPaths();
+		const TArray<FString> ProjectDirs = GitSourceControlUtils::GetSourceControlledAssetPaths();
 
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking,
@@ -747,7 +747,7 @@ bool FGitUpdateStatusWorker::Execute(FGitSourceControlCommand& InCommand)
 	else
 	{
 		// no path provided: only update the status of assets in Content/ directory and also Config files
-		const TArray<FString> ProjectDirs = GitSourceControlUtils::GetImportantGitPaths();
+		const TArray<FString> ProjectDirs = GitSourceControlUtils::GetSourceControlledAssetPaths();
 		
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -753,8 +753,14 @@ bool FGitUpdateStatusWorker::Execute(FGitSourceControlCommand& InCommand)
 	else
 	{
 		// no path provided: only update the status of assets in Content/ directory and also Config files
-		const TArray<FString> ProjectDirs {FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()), FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-										   FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};
+		const TArray<FString> ProjectDirs
+		{
+			FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
+			FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
+			FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
+			FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
+		};
+		
 		TMap<FString, FGitSourceControlState> UpdatedStates;
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);
 		GitSourceControlUtils::RemoveRedundantErrors(InCommand, TEXT("' is outside repository"));

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -171,9 +171,14 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 					UE_LOG(LogSourceControl, Log, TEXT("Git LFS Locking is enabled."));
 				}
 			}
-			const TArray<FString> ProjectDirs{FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
-											  FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-											  FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};
+			const TArray<FString> ProjectDirs
+			{
+				FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
+				FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
+				FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
+				FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
+			};
+
 			TArray<FString> StatusErrorMessages;
 			if (!GitSourceControlUtils::RunUpdateStatus(PathToGitBinary, PathToRepositoryRoot, bUsingGitLfsLocking, ProjectDirs, StatusErrorMessages, States))
 			{

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -171,13 +171,8 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 					UE_LOG(LogSourceControl, Log, TEXT("Git LFS Locking is enabled."));
 				}
 			}
-			const TArray<FString> ProjectDirs
-			{
-				FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
-				FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
-				FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
-				FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
-			};
+
+			const TArray<FString> ProjectDirs = GitSourceControlUtils::GetImportantGitPaths();
 
 			TArray<FString> StatusErrorMessages;
 			if (!GitSourceControlUtils::RunUpdateStatus(PathToGitBinary, PathToRepositoryRoot, bUsingGitLfsLocking, ProjectDirs, StatusErrorMessages, States))

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -172,7 +172,7 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 				}
 			}
 
-			const TArray<FString> ProjectDirs = GitSourceControlUtils::GetImportantGitPaths();
+			const TArray<FString> ProjectDirs = GitSourceControlUtils::GetSourceControlledAssetPaths();
 
 			TArray<FString> StatusErrorMessages;
 			if (!GitSourceControlUtils::RunUpdateStatus(PathToGitBinary, PathToRepositoryRoot, bUsingGitLfsLocking, ProjectDirs, StatusErrorMessages, States))

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1481,15 +1481,16 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	const FString AbsoluteProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
 	const FString AbsolutePluginsPath = FPaths::Combine(AbsoluteProjectPath, "Plugins/");
 	const FString AbsoluteBinariesPath = FPaths::Combine(AbsoluteProjectPath, "Binaries/");
+	const FString AbsoluteChecksumPath = FPaths::Combine(AbsoluteProjectPath, ".checksum");
 
 	//const TArray<FString>& RelativeFiles = RelativeFilenames(Files, InRepositoryRoot);
 	// Get the full remote status of the Content and Plugins folder, since it's the only lockable folder we track in editor. 
 	// This shows any new files as well.
 	// Also update the status of `.checksum`.
-	TArray<FString> FilesToDiff
+	const TArray<FString> FilesToDiff
 	{
 		FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
-		".checksum",
+		AbsoluteChecksumPath,
 		AbsoluteBinariesPath,
 		AbsolutePluginsPath,
 	};
@@ -1538,7 +1539,7 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 				if (!IsFileLFSLockable(NewerFileName))
 				{
 					// Check if there's newer binaries pending on this branch
-					if (bCurrentBranch && (NewerFileName == TEXT(".checksum") || NewerFilePath.StartsWith(AbsoluteBinariesPath, ESearchCase::IgnoreCase) ||
+					if (bCurrentBranch && (NewerFilePath == AbsoluteChecksumPath || NewerFilePath.StartsWith(AbsoluteBinariesPath, ESearchCase::IgnoreCase) ||
 						NewerFilePath.StartsWith(AbsolutePluginsPath, ESearchCase::IgnoreCase)))
 					{
 						Provider.bPendingRestart = true;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1479,9 +1479,9 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	TMap<FString, FString> NewerFiles;
 
 	const FString AbsoluteProjectDirPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
-	const FString AbsolutePluginsPath = FPaths::Combine(AbsoluteProjectDirPath, "Plugins/");
-	const FString AbsoluteBinariesPath = FPaths::Combine(AbsoluteProjectDirPath, "Binaries/");
-	const FString AbsoluteChecksumPath = FPaths::Combine(AbsoluteProjectDirPath, ".checksum");
+	const FString AbsolutePluginsDirPath = FPaths::Combine(AbsoluteProjectDirPath, "Plugins/");
+	const FString AbsoluteBinariesDirPath = FPaths::Combine(AbsoluteProjectDirPath, "Binaries/");
+	const FString AbsoluteChecksumFilePath = FPaths::Combine(AbsoluteProjectDirPath, ".checksum");
 
 	//const TArray<FString>& RelativeFiles = RelativeFilenames(Files, InRepositoryRoot);
 	// Get the full remote status of the Content and Plugins folder, since it's the only lockable folder we track in editor. 
@@ -1490,9 +1490,9 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	const TArray<FString> FilesToDiff
 	{
 		FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
-		AbsoluteChecksumPath,
-		AbsoluteBinariesPath,
-		AbsolutePluginsPath,
+		AbsoluteChecksumFilePath,
+		AbsoluteBinariesDirPath,
+		AbsolutePluginsDirPath,
 	};
 	
 	TArray<FString> ParametersLog{TEXT("--pretty="), TEXT("--name-only"), TEXT(""), TEXT("--")};
@@ -1539,8 +1539,8 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 				if (!IsFileLFSLockable(NewerFileName))
 				{
 					// Check if there's newer binaries pending on this branch
-					if (bCurrentBranch && (NewerFilePath == AbsoluteChecksumPath || NewerFilePath.StartsWith(AbsoluteBinariesPath, ESearchCase::IgnoreCase) ||
-						NewerFilePath.StartsWith(AbsolutePluginsPath, ESearchCase::IgnoreCase)))
+					if (bCurrentBranch && (NewerFilePath == AbsoluteChecksumFilePath || NewerFilePath.StartsWith(AbsoluteBinariesDirPath, ESearchCase::IgnoreCase) ||
+						NewerFilePath.StartsWith(AbsolutePluginsDirPath, ESearchCase::IgnoreCase)))
 					{
 						Provider.bPendingRestart = true;
 					}

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -795,6 +795,17 @@ bool GetRemoteUrl(const FString& InPathToGitBinary, const FString& InRepositoryR
 	return bResults;
 }
 
+const TArray<FString>& GetImportantGitPaths()
+{
+	return
+	{
+		FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
+		FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
+		FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
+		FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())
+	};
+}
+
 bool RunCommand(const FString& InCommand, const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FString>& InParameters,
 				const TArray<FString>& InFiles, TArray<FString>& OutResults, TArray<FString>& OutErrorMessages)
 {

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -795,7 +795,7 @@ bool GetRemoteUrl(const FString& InPathToGitBinary, const FString& InRepositoryR
 	return bResults;
 }
 
-TArray<FString> GetImportantGitPaths()
+TArray<FString> GetSourceControlledAssetPaths()
 {
 	return
 	{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1469,10 +1469,17 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 
 
 	//const TArray<FString>& RelativeFiles = RelativeFilenames(Files, InRepositoryRoot);
-	// Get the full remote status of the Content folder, since it's the only lockable folder we track in editor. 
+	// Get the full remote status of the Content and Plugins folder, since it's the only lockable folder we track in editor. 
 	// This shows any new files as well.
 	// Also update the status of `.checksum`.
-	TArray<FString> FilesToDiff{FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()), ".checksum", "Binaries/", "Plugins/"};
+	TArray<FString> FilesToDiff
+	{
+		FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
+		".checksum",
+		"Binaries/",
+		FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
+	};
+	
 	TArray<FString> ParametersLog{TEXT("--pretty="), TEXT("--name-only"), TEXT(""), TEXT("--")};
 	for (auto& Branch : BranchesToDiff)
 	{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1478,10 +1478,10 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 
 	TMap<FString, FString> NewerFiles;
 
-	const FString AbsoluteProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
-	const FString AbsolutePluginsPath = FPaths::Combine(AbsoluteProjectPath, "Plugins/");
-	const FString AbsoluteBinariesPath = FPaths::Combine(AbsoluteProjectPath, "Binaries/");
-	const FString AbsoluteChecksumPath = FPaths::Combine(AbsoluteProjectPath, ".checksum");
+	const FString AbsoluteProjectDirPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	const FString AbsolutePluginsPath = FPaths::Combine(AbsoluteProjectDirPath, "Plugins/");
+	const FString AbsoluteBinariesPath = FPaths::Combine(AbsoluteProjectDirPath, "Binaries/");
+	const FString AbsoluteChecksumPath = FPaths::Combine(AbsoluteProjectDirPath, ".checksum");
 
 	//const TArray<FString>& RelativeFiles = RelativeFilenames(Files, InRepositoryRoot);
 	// Get the full remote status of the Content and Plugins folder, since it's the only lockable folder we track in editor. 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1467,6 +1467,11 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 
 	TMap<FString, FString> NewerFiles;
 
+	// Get a relative path to the Plugins folder from the repository root
+	// without any directory walking up the path
+	auto ProjectPluginsPathRepoRelative = FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir());
+	FPaths::MakePathRelativeTo(ProjectPluginsPathRepoRelative, GetData(InRepositoryRoot));
+	ProjectPluginsPathRepoRelative.Split(TEXT("/"), nullptr, &ProjectPluginsPathRepoRelative);
 
 	//const TArray<FString>& RelativeFiles = RelativeFilenames(Files, InRepositoryRoot);
 	// Get the full remote status of the Content and Plugins folder, since it's the only lockable folder we track in editor. 
@@ -1523,7 +1528,7 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 				{
 					// Check if there's newer binaries pending on this branch
 					if (bCurrentBranch && (NewerFileName == TEXT(".checksum") || NewerFileName.StartsWith("Binaries/", ESearchCase::IgnoreCase) ||
-						NewerFileName.StartsWith("Plugins/", ESearchCase::IgnoreCase)))
+						NewerFileName.StartsWith(ProjectPluginsPathRepoRelative, ESearchCase::IgnoreCase)))
 					{
 						Provider.bPendingRestart = true;
 					}

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1478,11 +1478,9 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 
 	TMap<FString, FString> NewerFiles;
 
-	// Get a relative path to the Plugins folder from the repository root
-	// without any directory walking up the path
-	auto ProjectPluginsPathRepoRelative = FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir());
-	FPaths::MakePathRelativeTo(ProjectPluginsPathRepoRelative, GetData(InRepositoryRoot));
-	ProjectPluginsPathRepoRelative.Split(TEXT("/"), nullptr, &ProjectPluginsPathRepoRelative);
+	const FString AbsoluteProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	const FString AbsolutePluginsPath = FPaths::Combine(AbsoluteProjectPath, "Plugins/");
+	const FString AbsoluteBinariesPath = FPaths::Combine(AbsoluteProjectPath, "Binaries/");
 
 	//const TArray<FString>& RelativeFiles = RelativeFilenames(Files, InRepositoryRoot);
 	// Get the full remote status of the Content and Plugins folder, since it's the only lockable folder we track in editor. 
@@ -1492,8 +1490,8 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	{
 		FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),
 		".checksum",
-		"Binaries/",
-		FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir()),
+		AbsoluteBinariesPath,
+		AbsolutePluginsPath,
 	};
 	
 	TArray<FString> ParametersLog{TEXT("--pretty="), TEXT("--name-only"), TEXT(""), TEXT("--")};
@@ -1534,18 +1532,20 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 
 			for (const FString& NewerFileName : Intersection)
 			{
+				const FString& NewerFilePath = FPaths::ConvertRelativePathToFull(InRepositoryRoot, NewerFileName);
+
 				// Don't care about mergeable files (.collection, .ini, .uproject, etc)
 				if (!IsFileLFSLockable(NewerFileName))
 				{
 					// Check if there's newer binaries pending on this branch
-					if (bCurrentBranch && (NewerFileName == TEXT(".checksum") || NewerFileName.StartsWith("Binaries/", ESearchCase::IgnoreCase) ||
-						NewerFileName.StartsWith(ProjectPluginsPathRepoRelative, ESearchCase::IgnoreCase)))
+					if (bCurrentBranch && (NewerFileName == TEXT(".checksum") || NewerFilePath.StartsWith(AbsoluteBinariesPath, ESearchCase::IgnoreCase) ||
+						NewerFilePath.StartsWith(AbsolutePluginsPath, ESearchCase::IgnoreCase)))
 					{
 						Provider.bPendingRestart = true;
 					}
 					continue;
 				}
-				const FString& NewerFilePath = FPaths::ConvertRelativePathToFull(InRepositoryRoot, NewerFileName);
+
 				if (bCurrentBranch || !NewerFiles.Contains(NewerFilePath))
 				{
 					NewerFiles.Add(NewerFilePath, Branch);

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -795,7 +795,7 @@ bool GetRemoteUrl(const FString& InPathToGitBinary, const FString& InRepositoryR
 	return bResults;
 }
 
-const TArray<FString>& GetImportantGitPaths()
+TArray<FString> GetImportantGitPaths()
 {
 	return
 	{

--- a/Source/GitSourceControl/Private/SGitSourceControlSettings.cpp
+++ b/Source/GitSourceControl/Private/SGitSourceControlSettings.cpp
@@ -704,7 +704,7 @@ FReply SGitSourceControlSettings::OnClickedInitializeGitRepository()
 	{
 		// List of files to add to Revision Control (.uproject, Config/, Content/, Plugins/, Source/ files and .gitignore/.gitattributes if any)
 		TArray<FString> ProjectFiles;
-		for (const FString& Path : GitSourceControlUtils::GetImportantGitPaths())
+		for (const FString& Path : GitSourceControlUtils::GetSourceControlledAssetPaths())
 		{
 			ProjectFiles.Add(Path);
 		}

--- a/Source/GitSourceControl/Private/SGitSourceControlSettings.cpp
+++ b/Source/GitSourceControl/Private/SGitSourceControlSettings.cpp
@@ -704,10 +704,11 @@ FReply SGitSourceControlSettings::OnClickedInitializeGitRepository()
 	{
 		// List of files to add to Revision Control (.uproject, Config/, Content/, Plugins/, Source/ files and .gitignore/.gitattributes if any)
 		TArray<FString> ProjectFiles;
-		ProjectFiles.Add(FPaths::ProjectContentDir());
-		ProjectFiles.Add(FPaths::ProjectConfigDir());
-		ProjectFiles.Add(FPaths::ProjectPluginsDir());
-		ProjectFiles.Add(FPaths::GetProjectFilePath());
+		for (const FString& Path : GitSourceControlUtils::GetImportantGitPaths())
+		{
+			ProjectFiles.Add(Path);
+		}
+
 		if (FPaths::DirectoryExists(FPaths::GameSourceDir()))
 		{
 			ProjectFiles.Add(FPaths::GameSourceDir());

--- a/Source/GitSourceControl/Private/SGitSourceControlSettings.cpp
+++ b/Source/GitSourceControl/Private/SGitSourceControlSettings.cpp
@@ -702,10 +702,11 @@ FReply SGitSourceControlSettings::OnClickedInitializeGitRepository()
 	GitSourceControl.GetProvider().CheckGitAvailability();
 	if(GitSourceControl.GetProvider().IsAvailable())
 	{
-		// List of files to add to Revision Control (.uproject, Config/, Content/, Source/ files and .gitignore/.gitattributes if any)
+		// List of files to add to Revision Control (.uproject, Config/, Content/, Plugins/, Source/ files and .gitignore/.gitattributes if any)
 		TArray<FString> ProjectFiles;
 		ProjectFiles.Add(FPaths::ProjectContentDir());
 		ProjectFiles.Add(FPaths::ProjectConfigDir());
+		ProjectFiles.Add(FPaths::ProjectPluginsDir());
 		ProjectFiles.Add(FPaths::GetProjectFilePath());
 		if (FPaths::DirectoryExists(FPaths::GameSourceDir()))
 		{

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -167,6 +167,8 @@ bool GetCommitInfo(const FString& InPathToGitBinary, const FString& InRepository
  */
 bool GetRemoteUrl(const FString& InPathToGitBinary, const FString& InRepositoryRoot, FString& OutRemoteUrl);
 
+static const TArray<FString>& GetImportantGitPaths();
+
 /**
  * Run a Git command - output is a string TArray.
  *

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -167,8 +167,8 @@ bool GetCommitInfo(const FString& InPathToGitBinary, const FString& InRepository
  */
 bool GetRemoteUrl(const FString& InPathToGitBinary, const FString& InRepositoryRoot, FString& OutRemoteUrl);
 
-// A list of core folder and file paths that we will always check locks, status, etc on startup 
-TArray<FString> GetImportantGitPaths();
+// A list of asset paths that we will always check locks, status, etc on startup and periodically 
+TArray<FString> GetSourceControlledAssetPaths();
 
 /**
  * Run a Git command - output is a string TArray.

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -167,7 +167,8 @@ bool GetCommitInfo(const FString& InPathToGitBinary, const FString& InRepository
  */
 bool GetRemoteUrl(const FString& InPathToGitBinary, const FString& InRepositoryRoot, FString& OutRemoteUrl);
 
-TArray<FString>GetImportantGitPaths();
+// A list of core folder and file paths that we will always check locks, status, etc on startup 
+TArray<FString> GetImportantGitPaths();
 
 /**
  * Run a Git command - output is a string TArray.

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -167,7 +167,7 @@ bool GetCommitInfo(const FString& InPathToGitBinary, const FString& InRepository
  */
 bool GetRemoteUrl(const FString& InPathToGitBinary, const FString& InRepositoryRoot, FString& OutRemoteUrl);
 
-static const TArray<FString>& GetImportantGitPaths();
+TArray<FString>GetImportantGitPaths();
 
 /**
  * Run a Git command - output is a string TArray.


### PR DESCRIPTION
tldr; We've accidentally broken checking out files from the project plugin path within our fork, but the fix is compatible with the unmodified version and we believe still a correct change.

Context: We have a fork of this plugin and have made extensive changes in an effort to increase developer productivity without degrading the functionality of the plugin too much. As a result of this we accidentally broke the ability to checkout files from within the project plugins path. We resolved this and while this issue doesn't occur in the unmodified version of the plugin, we still believe that the changes made are correct and good.

The specifics as to what we changed and what broke is that the `git lfs locks` operation is really slow so we've tried to limit the number of times we call it for user initiated actions. The important location that was changed for this issue is that the Update Status action will no longer call `git lfs locks` and the LockState of the file will be `ELockState::Unset` and the context menu won't allow you to checkout the file (You can only check out lockable files that are `ELockState::NotLolcked` and up to date)

The fix is to make sure that the project plugins directory is checked in the various locations where we "update the SCC status of all packages", "update the status of all our files", etc. Previously it was only targeting the Content, Config and Project file paths so on startup and periodically it wouldn't get information about files in the plugins directory, but whenever we did Update Status on a single file (or folder) it would (in the unmodified version). By adding `FPaths::ProjectPluginsDir` to the various lists (and consolidating the lists) we ensure that the directory is checked when doing these project wide updates.

A bonus and related change is fixing some string literals pointing to the "Plugins/" and "Binaries/" directories. Our repo structure is such that we don't have those folders in the root, so those paths were never correct for us relative to the repo root. By using paths relative to the project dir we can ensure they are correct no matter how the repo is structured. 

We saw but didn't change anything related to the `.checksum` file because we don't have that file and aren't sure what it is or where it lives. We can deduce it exists in the project directory but didn't want to make changes that we can't verify.