### PR TITLE
Disable view changes menu

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -38,9 +38,6 @@
 #include "ToolMenuMisc.h"
 #endif
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
-#include "EditorModeManager.h"
-#endif
 #include "UObject/Linker.h"
 
 static const FName GitSourceControlMenuTabName(TEXT("GitSourceControlMenu"));
@@ -95,14 +92,6 @@ bool FGitSourceControlMenu::HaveRemoteUrl() const
 {
 	const FGitSourceControlModule& GitSourceControl = FGitSourceControlModule::Get();
 	return !GitSourceControl.GetProvider().GetRemoteUrl().IsEmpty();
-}
-
-bool FGitSourceControlMenu::CanCommit() const
-{
-	// The 'Submit Content' operation could lead to a world reload (in UEFN) that takes the user out of their selected editor mode.
-	// Piggy back on the 'CanAutoSave' functionality to determine if now is a good time to trigger a 'Submit Content' SCC operation.
-
-	return GLevelEditorModeTools().CanAutoSave() && FSourceControlWindows::CanChoosePackagesToCheckIn();
 }
 
 /// Prompt to save or discard all packages
@@ -535,20 +524,6 @@ void FGitSourceControlMenu::AddMenuExtension(FToolMenuSection& Builder)
 void FGitSourceControlMenu::AddMenuExtension(FMenuBuilder& Builder)
 #endif
 {
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
-	// UE 5.6 removed the submit content button, so re-create one here
-	Builder.AddMenuEntry(
-		"CommitAndPush",
-		LOCTEXT("GitCommit",				"Submit Content"),
-		LOCTEXT("GitPushTooltip",		"Opens a dialog with check in options for content and levels."),
-		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Submit"),
-		FUIAction(
-			FExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CommitClicked),
-			FCanExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CanCommit)
-		)
-	);
-#endif
-	
 	Builder.AddMenuEntry(
 #if ENGINE_MAJOR_VERSION >= 5
 		"GitPush",

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -101,11 +101,8 @@ bool FGitSourceControlMenu::CanCommit() const
 {
 	// The 'Submit Content' operation could lead to a world reload (in UEFN) that takes the user out of their selected editor mode.
 	// Piggy back on the 'CanAutoSave' functionality to determine if now is a good time to trigger a 'Submit Content' SCC operation.
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
+
 	return GLevelEditorModeTools().CanAutoSave() && FSourceControlWindows::CanChoosePackagesToCheckIn();
-#else
-	return true;
-#endif
 }
 
 /// Prompt to save or discard all packages

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -560,7 +560,7 @@ bool FGitSourceControlProvider::UsesLocalReadOnlyState() const
 
 bool FGitSourceControlProvider::UsesChangelists() const
 {
-	return true;
+	return false;
 }
 
 bool FGitSourceControlProvider::UsesCheckout() const
@@ -593,7 +593,7 @@ bool FGitSourceControlProvider::AllowsDiffAgainstDepot() const
 
 bool FGitSourceControlProvider::UsesUncontrolledChangelists() const
 {
-	return true;
+	return false;
 }
 
 bool FGitSourceControlProvider::UsesSnapshots() const

--- a/Source/GitSourceControl/Public/GitSourceControlMenu.h
+++ b/Source/GitSourceControl/Public/GitSourceControlMenu.h
@@ -32,9 +32,8 @@ protected:
 
 private:
 	bool HaveRemoteUrl() const;
-	bool CanCommit() const;
 
-	bool SaveDirtyPackages();
+	bool				SaveDirtyPackages();
 
 	bool StashAwayAnyModifications();
 	void ReApplyStashedModifications();


### PR DESCRIPTION
We've had several team members get confused by the "View Changes" menu items because logically they want to do that, but functionally the menu doesn't work. The menu works by showing various changelists but since git doesn't use changelists (unlike Perforce) then the menu doesn't do anything.

I noticed that the plugin has changelist support enabled and by disabling that then the "View Changes" menu item goes away AND the original "Submit Content" button appears in the menu. I've done some testing and so far everything is working as expected.

Changelist support was added to the plugin 2 years (unclear if this fork or from upstream) but there is no context around why it was enabled: https://github.com/ProjectBorealis/UEGitPlugin/commit/31273ac137c85357ea0d042cda1cea949f41f550

Does anyone have additional context about why this would be a bad change? Or is this correct to take?