### PR TITLE
Conditionally add a git Submit Content button if Changelists are enabled

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -538,18 +538,22 @@ void FGitSourceControlMenu::AddMenuExtension(FToolMenuSection& Builder)
 void FGitSourceControlMenu::AddMenuExtension(FMenuBuilder& Builder)
 #endif
 {
+	// UE 5.6 doesn't show the Submit Content button if changelists are enabled
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
-	// UE 5.6 removed the submit content button, so re-create one here
-	Builder.AddMenuEntry(
-		"CommitAndPush",
-		LOCTEXT("GitCommit",				"Submit Content"),
-		LOCTEXT("GitPushTooltip",		"Opens a dialog with check in options for content and levels."),
-		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Submit"),
-		FUIAction(
-			FExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CommitClicked),
-			FCanExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CanCommit)
-		)
-	);
+	const FGitSourceControlProvider& Provider = FGitSourceControlModule::Get().GetProvider();
+	if (Provider.UsesChangelists())
+	{
+		Builder.AddMenuEntry(
+			"CommitAndPush",
+			LOCTEXT("GitCommit",				"Submit Content"),
+			LOCTEXT("GitPushTooltip",		"Opens a dialog with check in options for content and levels."),
+			FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Submit"),
+			FUIAction(
+				FExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CommitClicked),
+				FCanExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CanCommit)
+			)
+		);
+	}
 #endif
 	
 	Builder.AddMenuEntry(


### PR DESCRIPTION
Only add a "Submit Content" button from the plugin if changelists are enabled.

Following on from some learnings from a cancelled PR (https://github.com/ProjectBorealis/UEGitPlugin/pull/229) I've got a follow up that should be an improvement for everyone depending on your use case.

Use Case 1: Default Plugin Settings - Changelists enabled
Under these settings the default engine "Submit Content" button was removed and the plugin had to manually add one. My assumption is that Epic expects anyone with changelists enabled to submit from the View Changes menu. As the plugin enables changelists to better support staging OFPA it means we lose the engine button and need to add a custom button.

Outcome from this PR: No change. Changelists are enabled by default and so the menu entry is added

Use Case 2: Disabling changelist support
Our workflow automatically stages all changes which means the improvements for OFPA don't apply. That means the "View Changes" menu item doesn't work for us and is a trap that we want to remove. By disabling changelist support it means the "View Changes" menu goes away and the default "Submit Content" button appears again, but the original code unconditionally adds another "Submit Content" button leaving us with duplicates without the change.

Outcome from this PR: The new "Submit Content" button will not be added and the default engine button can be used instead.